### PR TITLE
fix: skip API deploy on pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,10 +82,12 @@ jobs:
           config_file_location: /
           skip_app_build: true
 
-  # ── API → Function App (needs Azure Login) ──
+  # ── API → Function App (needs Azure Login — push/dispatch only, OIDC creds don't match PR subject) ──
   deploy_api:
     needs: changes
-    if: needs.changes.outputs.api == 'true' || github.event_name == 'workflow_dispatch'
+    if: |
+      github.event_name != 'pull_request' &&
+      (needs.changes.outputs.api == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     name: Deploy API
     steps:


### PR DESCRIPTION
The Azure OIDC federated credential only matches \ef:refs/heads/main\, so the Deploy API job always fails on PRs with \AADSTS700213: No matching federated identity record\. This adds a condition to skip the API deploy on \pull_request\ events — it only runs on \push\ to main and \workflow_dispatch\.