### PR TITLE
feat: add database seeding and auth email-fallback lookup

### DIFF
--- a/api/host.json
+++ b/api/host.json
@@ -8,10 +8,6 @@
       }
     }
   },
-  "extensionBundle": {
-    "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[4.*, 5.0.0)"
-  },
   "languageWorkers": {
     "node": {
       "arguments": []

--- a/api/src/cosmosdb.ts
+++ b/api/src/cosmosdb.ts
@@ -6,12 +6,14 @@ const connectionString = process.env.COSMOS_CONNECTION_STRING
 const databaseId = process.env.COSMOS_DATABASE || 'scout-meal-planner'
 
 if (!endpoint && !connectionString) {
-  throw new Error('Either COSMOS_ENDPOINT or COSMOS_CONNECTION_STRING environment variable is required')
+  console.warn('WARNING: Neither COSMOS_ENDPOINT nor COSMOS_CONNECTION_STRING is set. Database calls will fail.')
 }
 
-const client = endpoint
-  ? new CosmosClient({ endpoint, aadCredentials: new DefaultAzureCredential() })
-  : new CosmosClient(connectionString!)
+const client = (endpoint || connectionString)
+  ? (endpoint
+      ? new CosmosClient({ endpoint, aadCredentials: new DefaultAzureCredential() })
+      : new CosmosClient(connectionString!))
+  : null as unknown as CosmosClient
 
 let database: Database
 let containers: Record<string, Container> = {}
@@ -26,8 +28,65 @@ const containerDefinitions = [
 
 let initialized = false
 
+/** Seed data: pre-configured troops and members created on first startup */
+const seedTroops = [
+  {
+    id: '00000000-0000-0000-0000-000000000001',
+    name: 'Troop 1 Bolton',
+    inviteCode: 'TROOP-B01T',
+    createdBy: 'seed',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  },
+]
+
+const seedMembers = [
+  {
+    id: '00000000-0000-0000-0000-00000000000A',
+    troopId: '00000000-0000-0000-0000-000000000001',
+    userId: '',
+    email: 'roberts_andy@hotmail.com',
+    displayName: 'Andy Roberts',
+    role: 'troopAdmin',
+    status: 'active',
+    joinedAt: Date.now(),
+  },
+]
+
+async function seedDatabase(): Promise<void> {
+  try {
+    for (const troop of seedTroops) {
+      try {
+        await containers['troops'].item(troop.id, troop.id).read()
+      } catch (err: any) {
+        if (err.code === 404) {
+          await containers['troops'].items.create(troop)
+          console.log(`Seeded troop: ${troop.name}`)
+        }
+      }
+    }
+
+    for (const member of seedMembers) {
+      try {
+        await containers['members'].item(member.id, member.troopId).read()
+      } catch (err: any) {
+        if (err.code === 404) {
+          await containers['members'].items.create(member)
+          console.log(`Seeded member: ${member.email} as ${member.role}`)
+        }
+      }
+    }
+  } catch (err) {
+    console.warn('Seed database failed (non-fatal):', err)
+  }
+}
+
 export async function initDatabase(): Promise<void> {
   if (initialized) return
+
+  if (!endpoint && !connectionString) {
+    throw new Error('Either COSMOS_ENDPOINT or COSMOS_CONNECTION_STRING environment variable is required')
+  }
 
   const { database: db } = await client.databases.createIfNotExists({ id: databaseId })
   database = db
@@ -39,6 +98,8 @@ export async function initDatabase(): Promise<void> {
     })
     containers[def.id] = container
   }
+
+  await seedDatabase()
 
   initialized = true
 }

--- a/api/src/functions/members.ts
+++ b/api/src/functions/members.ts
@@ -104,18 +104,23 @@ async function membersHandler(req: HttpRequest, context: InvocationContext): Pro
 async function memberMeHandler(req: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
   context.log('GET /api/members/me')
 
-  const auth = await getTroopContext(req, context)
-  if (!auth) {
-    // User is authenticated but has no troop membership
-    return { status: 404, jsonBody: { error: 'No troop membership found' } }
-  }
+  try {
+    const auth = await getTroopContext(req, context)
+    if (!auth) {
+      // User is authenticated but has no troop membership
+      return { status: 404, jsonBody: { error: 'No troop membership found' } }
+    }
 
-  return {
-    jsonBody: {
-      troopId: auth.troopId,
-      userId: auth.userId,
-      role: auth.role,
-    },
+    return {
+      jsonBody: {
+        troopId: auth.troopId,
+        userId: auth.userId,
+        role: auth.role,
+      },
+    }
+  } catch (err) {
+    context.error('GET /api/members/me failed:', err)
+    return { status: 500, jsonBody: { error: 'Internal server error' } }
   }
 }
 

--- a/api/src/middleware/auth.ts
+++ b/api/src/middleware/auth.ts
@@ -1,6 +1,6 @@
 import { HttpRequest, InvocationContext } from '@azure/functions'
 import { createRemoteJWKSet, jwtVerify, JWTPayload } from 'jose'
-import { queryItems } from '../cosmosdb.js'
+import { queryItems, update } from '../cosmosdb.js'
 
 const CLIENT_ID = process.env.ENTRA_CLIENT_ID
 
@@ -70,9 +70,25 @@ export async function getTroopContext(req: HttpRequest, context: InvocationConte
     [{ name: '@userId', value: claims.userId }]
   )
 
-  if (members.length === 0) return null
+  let member = members[0]
 
-  const member = members[0]
+  // Fallback: match by email for seeded members whose userId hasn't been set yet
+  if (!member && claims.email) {
+    const byEmail = await queryItems<any>(
+      'members',
+      'SELECT * FROM c WHERE c.email = @email AND c.status = "active" AND (c.userId = "" OR NOT IS_DEFINED(c.userId))',
+      [{ name: '@email', value: claims.email }]
+    )
+    if (byEmail.length > 0) {
+      member = byEmail[0]
+      // Backfill the real userId so future lookups use the fast path
+      member.userId = claims.userId
+      member.displayName = claims.displayName || member.displayName
+      await update('members', member.id, member, member.troopId)
+    }
+  }
+
+  if (!member) return null
   return {
     userId: claims.userId,
     email: claims.email,


### PR DESCRIPTION
## Summary

Add database seed data for initial troop/member setup and improve auth middleware with email-based fallback lookup.

### Changes

- **Database seeding** — Seed a default troop ("Troop 1 Bolton") and admin member on first DB init
- **Deferred Cosmos client error** — Warn at module load instead of throwing; defer the hard error to `initDatabase()` so the app can start without Cosmos env vars (e.g. for unit tests)
- **Auth email fallback** — When a user logs in but has no member record by `userId`, fall back to email-based lookup for seeded members and backfill the `userId` for future lookups
- **Error handling** — Wrap `GET /api/members/me` in try/catch for resilient error responses
- **Cleanup** — Remove unused `extensionBundle` from `api/host.json`