### PR TITLE
Fix calendar alignment and switch to date range picker

### DIFF
--- a/.github/copilot-code-review-instructions.md
+++ b/.github/copilot-code-review-instructions.md
@@ -1,0 +1,44 @@
+## Code Review
+
+When reviewing pull requests, check for:
+
+### Correctness
+- TypeScript strict mode compliance — no `any` casts, no `@ts-ignore`
+- Zod schemas in `api/src/schemas.ts` validate all API inputs; no raw `req.body` access
+- TanStack Query hooks follow existing patterns in `src/hooks/`
+- Frontend components use shadcn/ui primitives from `src/components/ui/`
+- `date-fns` for date operations, not raw `Date` manipulation
+
+### Testing
+- API functions have corresponding `*.test.ts` files in `api/src/functions/`
+- Non-trivial frontend logic has unit tests
+- Tests use Vitest, not Jest
+
+### Conventions
+- No changes to `infra/` unless the issue explicitly requires it
+- No changes to `api/src/middleware/auth.ts` unless the issue explicitly requires it
+- No new dependencies without clear justification
+- Branch targets `main` (trunk-based, no `develop` branch)
+
+## Security Review
+
+Flag any of the following as blocking issues:
+
+### Authentication & Authorization
+- API endpoints must call `validateToken()` or `getTroopContext()` before any data access
+- Role checks via `checkPermission()` must guard write operations
+- No hard-coded secrets, tokens, or connection strings
+
+### Input Validation
+- All user input must pass through Zod schemas before use
+- No string interpolation in Cosmos DB queries — use parameterized queries only
+- URL and path inputs must be validated; no open redirects
+
+### Data Exposure
+- API responses must not leak internal IDs, stack traces, or other users' data
+- Error responses must use generic messages, not raw error details
+- No `.env` files, secrets, or credentials committed
+
+### Dependencies
+- Flag new dependencies for known vulnerabilities
+- Flag dependencies that are unmaintained or have low adoption

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,6 +57,29 @@ npm run lint
 - API schemas defined with Zod in `api/src/schemas.ts`
 - Frontend auth via MSAL (Microsoft Entra ID, /consumers endpoint)
 - API auth via JWT validation middleware (`api/src/middleware/auth.ts`)
+- UI components use shadcn/ui (Radix + Tailwind) in `src/components/ui/`
+- Data fetching uses TanStack Query hooks in `src/hooks/`
+- API client functions live in `src/lib/api.ts`
+
+## Agent Workflow
+
+When assigned an issue:
+
+1. Read the issue carefully. If it references other files or features, explore them first.
+2. Create a branch named `issue-<number>-<short-description>` from `main`.
+3. Implement the change following the conventions above.
+4. For API changes: add or update Zod schemas in `api/src/schemas.ts`, add the function in `api/src/functions/`, and write tests alongside (`*.test.ts`).
+5. For frontend changes: use existing UI components from `src/components/ui/`, add hooks in `src/hooks/`, and write tests for non-trivial logic.
+6. Run the full validation: `npm run build && npm test && npm run lint && cd api && npm run build && npm test`.
+7. All builds and tests must pass before opening a PR.
+8. Open a PR targeting `main` with a clear description of what changed and why.
+
+## Do Not
+
+- Do not modify `infra/` (Bicep) files unless the issue explicitly requests infrastructure changes.
+- Do not commit `.env` files or secrets.
+- Do not add new dependencies without a clear reason stated in the PR description.
+- Do not change the auth middleware (`api/src/middleware/auth.ts`) unless the issue specifically requires it.
 
 ## Cosmos DB
 

--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -1,0 +1,25 @@
+# Setup steps for GitHub Copilot coding agent
+# Runs after the devcontainer starts, before the agent begins coding.
+# The agent uses these to validate its work (build + test) before opening a PR.
+
+steps:
+  - name: Install frontend dependencies
+    run: npm ci
+
+  - name: Install API dependencies
+    run: cd api && npm ci
+
+  - name: Build frontend
+    run: npm run build
+
+  - name: Build API
+    run: cd api && npm run build
+
+  - name: Run frontend tests
+    run: npm test
+
+  - name: Run API tests
+    run: cd api && npm test
+
+  - name: Lint
+    run: npm run lint

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,18 @@
 # Pull Request
 
 ## Description
-<!-- Brief summary of what this PR does -->
+<!-- Brief summary of what this PR does and why -->
 
 ## Type of Change
-<!-- Check the one that applies -->
 
-- [ ] `feature/*` → `develop` (new feature)
-- [ ] `develop` → `release/*` (release prep)
-- [ ] `release/*` → `main` (production release)
-- [ ] `hotfix/*` → `main` (emergency fix)
-- [ ] Other (describe):
+- [ ] Feature (new functionality)
+- [ ] Fix (bug fix)
+- [ ] Hotfix (emergency production fix)
+- [ ] Chore (refactor, docs, tests, CI)
 
 ## Checklist
 
-- [ ] Code builds without errors (`npm run build`)
-- [ ] Tests pass (`npm test`)
-- [ ] API builds without errors (`cd api && npm run build`)
-- [ ] Tested locally with `.\dev.ps1`
-
-## GitFlow Reminders
-
-- **Features** merge into `develop` only
-- **Releases** branch from `develop`, merge into both `main` and `develop`
-- **Hotfixes** branch from `main`, merge into both `main` and `develop`
+- [ ] Code builds without errors (`npm run build && cd api && npm run build`)
+- [ ] Tests pass (`npm test && cd api && npm test`)
+- [ ] Linting passes (`npm run lint`)
+- [ ] No new dependencies added without justification

--- a/src/components/CreateEventDialog.tsx
+++ b/src/components/CreateEventDialog.tsx
@@ -14,10 +14,8 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Calendar as CalendarComponent } from '@/components/ui/calendar'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { Calendar as CalendarIcon } from '@phosphor-icons/react'
 import { format, eachDayOfInterval } from 'date-fns'
-import { cn } from '@/lib/utils'
+import type { DateRange } from 'react-day-picker'
 
 interface CreateEventDialogProps {
   open: boolean
@@ -27,8 +25,7 @@ interface CreateEventDialogProps {
 
 export function CreateEventDialog({ open, onOpenChange, onCreateEvent }: CreateEventDialogProps) {
   const [name, setName] = useState('')
-  const [startDate, setStartDate] = useState<Date>()
-  const [endDate, setEndDate] = useState<Date>()
+  const [dateRange, setDateRange] = useState<DateRange | undefined>()
   const [description, setDescription] = useState('')
   const [link, setLink] = useState('')
   const [hike, setHike] = useState(false)
@@ -37,11 +34,11 @@ export function CreateEventDialog({ open, onOpenChange, onCreateEvent }: CreateE
   const [cabinCamping, setCabinCamping] = useState(false)
 
   const handleSubmit = () => {
-    if (!name || !startDate || !endDate) return
+    if (!name || !dateRange?.from || !dateRange?.to) return
 
     const days: EventDay[] = eachDayOfInterval({
-      start: startDate,
-      end: endDate
+      start: dateRange.from,
+      end: dateRange.to
     }).map(date => ({
       date: format(date, 'yyyy-MM-dd'),
       meals: []
@@ -50,8 +47,8 @@ export function CreateEventDialog({ open, onOpenChange, onCreateEvent }: CreateE
     const newEvent: Event = {
       id: `event-${Date.now()}`,
       name,
-      startDate: format(startDate, 'yyyy-MM-dd'),
-      endDate: format(endDate, 'yyyy-MM-dd'),
+      startDate: format(dateRange.from, 'yyyy-MM-dd'),
+      endDate: format(dateRange.to, 'yyyy-MM-dd'),
       days,
       description: description || undefined,
       link: link || undefined,
@@ -65,8 +62,7 @@ export function CreateEventDialog({ open, onOpenChange, onCreateEvent }: CreateE
 
     onCreateEvent(newEvent)
     setName('')
-    setStartDate(undefined)
-    setEndDate(undefined)
+    setDateRange(undefined)
     setDescription('')
     setLink('')
     setHike(false)
@@ -78,7 +74,7 @@ export function CreateEventDialog({ open, onOpenChange, onCreateEvent }: CreateE
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[500px]">
+      <DialogContent className="sm:max-w-[640px]">
         <DialogHeader>
           <DialogTitle>Create New Event</DialogTitle>
           <DialogDescription>
@@ -106,55 +102,29 @@ export function CreateEventDialog({ open, onOpenChange, onCreateEvent }: CreateE
             />
           </div>
           <div className="grid gap-2">
-            <Label>Start Date</Label>
-            <Popover>
-              <PopoverTrigger asChild>
-                <Button
-                  variant="outline"
-                  className={cn(
-                    'justify-start text-left font-normal',
-                    !startDate && 'text-muted-foreground'
-                  )}
-                >
-                  <CalendarIcon className="mr-2" size={18} />
-                  {startDate ? format(startDate, 'PPP') : 'Pick a date'}
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-auto p-0">
-                <CalendarComponent
-                  mode="single"
-                  selected={startDate}
-                  onSelect={setStartDate}
-                  initialFocus
-                />
-              </PopoverContent>
-            </Popover>
-          </div>
-          <div className="grid gap-2">
-            <Label>End Date</Label>
-            <Popover>
-              <PopoverTrigger asChild>
-                <Button
-                  variant="outline"
-                  className={cn(
-                    'justify-start text-left font-normal',
-                    !endDate && 'text-muted-foreground'
-                  )}
-                >
-                  <CalendarIcon className="mr-2" size={18} />
-                  {endDate ? format(endDate, 'PPP') : 'Pick a date'}
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-auto p-0">
-                <CalendarComponent
-                  mode="single"
-                  selected={endDate}
-                  onSelect={setEndDate}
-                  disabled={(date) => startDate ? date < startDate : false}
-                  initialFocus
-                />
-              </PopoverContent>
-            </Popover>
+            <Label>Trip Dates</Label>
+            <div className="text-sm text-muted-foreground">
+              {dateRange?.from ? (
+                dateRange.to ? (
+                  <>
+                    {format(dateRange.from, 'MMM d, yyyy')} — {format(dateRange.to, 'MMM d, yyyy')}
+                  </>
+                ) : (
+                  <>
+                    {format(dateRange.from, 'MMM d, yyyy')} — <span className="italic">select end date</span>
+                  </>
+                )
+              ) : (
+                'Select start and end dates'
+              )}
+            </div>
+            <CalendarComponent
+              mode="range"
+              selected={dateRange}
+              onSelect={setDateRange}
+              numberOfMonths={2}
+              disabled={{ before: new Date() }}
+            />
           </div>
           <div className="grid gap-2">
             <Label>Event Characteristics</Label>
@@ -208,7 +178,7 @@ export function CreateEventDialog({ open, onOpenChange, onCreateEvent }: CreateE
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Cancel
           </Button>
-          <Button onClick={handleSubmit} disabled={!name || !startDate || !endDate}>
+          <Button onClick={handleSubmit} disabled={!name || !dateRange?.from || !dateRange?.to}>
             Create Event
           </Button>
         </DialogFooter>

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -19,52 +19,52 @@ function Calendar({
       classNames={{
         months: "flex flex-col sm:flex-row gap-2",
         month: "flex flex-col gap-4",
-        caption: "flex justify-center pt-1 relative items-center w-full",
+        month_caption: "flex justify-center pt-1 relative items-center w-full",
         caption_label: "text-sm font-medium",
         nav: "flex items-center gap-1",
-        nav_button: cn(
+        button_previous: cn(
           buttonVariants({ variant: "outline" }),
-          "size-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+          "size-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute left-1"
         ),
-        nav_button_previous: "absolute left-1",
-        nav_button_next: "absolute right-1",
-        table: "w-full border-collapse space-x-1",
-        head_row: "flex",
-        head_cell:
+        button_next: cn(
+          buttonVariants({ variant: "outline" }),
+          "size-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute right-1"
+        ),
+        month_grid: "w-full border-collapse",
+        weekdays: "flex",
+        weekday:
           "text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]",
-        row: "flex w-full mt-2",
-        cell: cn(
-          "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md",
+        week: "flex w-full mt-2",
+        day: cn(
+          "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].range-end)]:rounded-r-md",
           props.mode === "range"
-            ? "[&:has(>.day-range-end)]:rounded-r-md [&:has(>.day-range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
+            ? "[&:has(>.range-end)]:rounded-r-md [&:has(>.range-start)]:rounded-l-md first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md"
             : "[&:has([aria-selected])]:rounded-md"
         ),
-        day: cn(
+        day_button: cn(
           buttonVariants({ variant: "ghost" }),
           "size-8 p-0 font-normal aria-selected:opacity-100"
         ),
-        day_range_start:
-          "day-range-start aria-selected:bg-primary aria-selected:text-primary-foreground",
-        day_range_end:
-          "day-range-end aria-selected:bg-primary aria-selected:text-primary-foreground",
-        day_selected:
+        range_start:
+          "range-start aria-selected:bg-primary aria-selected:text-primary-foreground",
+        range_end:
+          "range-end aria-selected:bg-primary aria-selected:text-primary-foreground",
+        selected:
           "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-        day_today: "bg-accent text-accent-foreground",
-        day_outside:
-          "day-outside text-muted-foreground aria-selected:text-muted-foreground",
-        day_disabled: "text-muted-foreground opacity-50",
-        day_range_middle:
+        today: "bg-accent text-accent-foreground",
+        outside:
+          "text-muted-foreground aria-selected:text-muted-foreground",
+        disabled: "text-muted-foreground opacity-50",
+        range_middle:
           "aria-selected:bg-accent aria-selected:text-accent-foreground",
-        day_hidden: "invisible",
+        hidden: "invisible",
         ...classNames,
       }}
       components={{
-        PreviousMonthButton: ({ className, ...props }) => (
-          <ChevronLeft className={cn("size-4", className)} {...props} />
-        ),
-        NextMonthButton: ({ className, ...props }) => (
-          <ChevronRight className={cn("size-4", className)} {...props} />
-        ),
+        Chevron: ({ orientation, className }) => {
+          const Icon = orientation === "left" ? ChevronLeft : ChevronRight
+          return <Icon className={cn("size-4", className)} />
+        },
       }}
       {...props}
     />


### PR DESCRIPTION
## Description

Replaces the two separate date popover pickers in Create Event with a single inline 2-month range calendar (click start date, click end date — hotel-booking style). Also fixes the calendar day alignment issue caused by using react-day-picker v8 class names with v9.

## Changes

### Date range picker (`CreateEventDialog.tsx`)
- Replaced two separate `Popover` + single-mode `Calendar` controls with one inline `Calendar` in `mode="range"` showing 2 months side-by-side
- Consolidated `startDate` / `endDate` state into a single `DateRange` object
- Shows selected range summary above the calendar (e.g. \"Apr 25, 2026 — Apr 27, 2026\")
- Past dates are disabled
- Widened dialog to `640px` to fit the 2-month layout

### Calendar v9 fix (`ui/calendar.tsx`)
- Updated all class names from react-day-picker **v8** to **v9** (`table` → `month_grid`, `row` → `week`, `cell` → `day`, `day` → `day_button`, `head_row` → `weekdays`, etc.)
- Updated `components` prop from `PreviousMonthButton` / `NextMonthButton` to single `Chevron` component
- Fixes weekday header and day button alignment

### Repo housekeeping (carried from previous branch)
- Switched branching strategy from GitFlow to trunk-based (docs + CI)
- Fixed Vite port (`5173` → `5000`) and API proxy target (`3001` → `7071`) for SWA CLI
- Added verbose logging config to `api/host.json`"