### PR TITLE
docs: add BRD, PRD v1.2, and privacy policy for Scout Meal Planner MVP

### DIFF
--- a/.copilot-tracking/brd-sessions/scout-meal-planner-mvp.state.json
+++ b/.copilot-tracking/brd-sessions/scout-meal-planner-mvp.state.json
@@ -1,0 +1,76 @@
+{
+  "brdFile": "docs/brds/scout-meal-planner-mvp-brd.md",
+  "lastAccessed": "2026-04-18T00:00:00Z",
+  "currentPhase": "finalized",
+  "questionsAsked": [
+    "initiative-name",
+    "business-problem",
+    "business-driver",
+    "initiative-type",
+    "primary-stakeholders",
+    "meeting-workflow",
+    "recording-methods",
+    "shopping-and-packing",
+    "must-have-for-launch",
+    "can-wait",
+    "timeline",
+    "meeting-time-baseline",
+    "shopping-equipment-errors",
+    "troop-size",
+    "scout-adoption",
+    "parent-access",
+    "biggest-risk"
+  ],
+  "answeredQuestions": {
+    "initiative-name": "Scout Meal Planner MVP Launch — pilot with a single scout troop, potential expansion to other troops",
+    "business-problem": "Meal planning takes too long in meetings; scouts record things inconsistently; communication breakdowns between scouts and leaders result in incorrect food purchases, wrong equipment, and less time for other activities",
+    "business-driver": "Operational efficiency",
+    "initiative-type": "New product pilot with potential multi-troop expansion",
+    "primary-stakeholders": "Scoutmaster (sponsor), Assistant Scoutmaster, SPL (youth leader), Scouts (primary users), Parents of scouts (secondary users)",
+    "meeting-workflow": "SPL-led meeting: logistics briefing → meal list with parameters → brainstorm and vote → patrol assignment → detailed patrol planning → handoff to Scoutmaster → transcribe and send to parents → shop → pack → post-trip retro",
+    "recording-methods": "Inconsistent: paper, phones, memory. Scoutmaster manually transcribes. No reusable recipe record.",
+    "shopping-and-packing": "Shopping list divided by meal, assigned to individual scouts. Scouts buy and bring to departure point.",
+    "must-have-for-launch": "Full meal planning workflow for a trip plus recipe library for reuse",
+    "can-wait": "Multi-troop support, cross-troop recipe sharing, advanced filters/favorites/feedback",
+    "timeline": "Prototype by May 2026, live by September 2026",
+    "meeting-time-baseline": "30-60+ minutes per meeting for meal planning",
+    "shopping-equipment-errors": "Most trips have issues — also common: recipe steps incomplete or not brought on trip",
+    "troop-size": "~25 scouts, ~10 adult leaders, occasional parents/guests. Trip groups 8-20+ people.",
+    "scout-adoption": "Ages 12-18, generally comfortable with web apps. Mobile-first web required. Native app is stretch goal.",
+    "parent-access": "Shareable link is sufficient — no parent login needed for MVP",
+    "biggest-risk": "Scouting America technology platform compliance for youth-facing app. Need PII handling, communication compliance, content moderation (Azure Content Safety or similar).",
+    "patrol-assignment": "Not in MVP — one scout (patrol leader) records information. No patrol management in-app.",
+    "brainstorming-voting": "Not in MVP — SPL records decided meals after in-person discussion.",
+    "shopping-assignment": "App should email shopping list. No in-app assignment to individual scout shoppers.",
+    "recipe-on-trip": "Recipes must be printable. Offline access is a future nice-to-have."
+  },
+  "referencesProcessed": [
+    {
+      "file": "PRD.md",
+      "status": "analyzed",
+      "keyFindings": "Detailed product features: event/meal scheduling, recipe management with variations, dynamic scaling, equipment tracking, shopping list generation, custom notes, scout feedback system. Design direction, component selection, and UX patterns defined."
+    }
+  ],
+  "nextActions": [
+    "Review and validate full BRD for completeness",
+    "Confirm requirement priorities with stakeholder",
+    "Finalize document for approval"
+  ],
+  "qualityChecks": [
+    "objectives-defined-with-baselines",
+    "stakeholders-documented",
+    "scope-defined",
+    "as-is-process-documented",
+    "to-be-process-documented",
+    "requirements-elicited",
+    "risks-documented",
+    "dependencies-documented",
+    "constraints-documented",
+    "benefits-documented",
+    "data-requirements-documented"
+  ],
+  "userPreferences": {
+    "detail-level": "comprehensive",
+    "question-style": "structured"
+  }
+}

--- a/.copilot-tracking/prd-sessions/scout-meal-planner-mvp.state.json
+++ b/.copilot-tracking/prd-sessions/scout-meal-planner-mvp.state.json
@@ -1,0 +1,82 @@
+{
+  "prdFile": "docs/prds/scout-meal-planner-mvp.md",
+  "lastAccessed": "2026-04-18T18:00:00Z",
+  "currentPhase": "finalized",
+  "questionsAsked": [
+    "product-name", "target-users", "core-problem", "success-metrics",
+    "scope-in", "scope-out", "assumptions", "constraints",
+    "business-objectives", "stakeholders", "current-process", "future-process",
+    "risks", "dependencies", "data-requirements", "design-direction",
+    "performance-targets", "cicd-pipeline", "monitoring", "rollback",
+    "test-coverage", "content-moderation-testing"
+  ],
+  "answeredQuestions": {
+    "product-name": "Scout Meal Planner",
+    "target-users": "SPL, Scoutmaster, Scouts, Assistant Scoutmaster, Parents",
+    "core-problem": "Meal planning consumes excessive meeting time, produces inconsistent records, creates communication breakdowns",
+    "success-metrics": "Meeting time ≤15min, zero shopping errors, zero forgotten equipment, 100% recipe availability, 80% adoption, ≥50% feedback rate",
+    "scope-in": "Event mgmt, meal scheduling, recipe mgmt, scaling, shopping/equipment lists, printable recipes, shareable link, feedback, content moderation, auth/RBAC",
+    "scope-out": "Multi-troop, patrol mgmt, brainstorming/voting, shopper assignment, advanced search, analytics dashboards, budget tracking, offline/PWA, native apps, external integrations",
+    "assumptions": "Web browser access, 3 patrols, internet during meetings, Scoutmaster currently transcribes manually",
+    "constraints": "Single developer, prototype May 2026, live Sep 2026, youth PII minimal, Scouting America compliance, content moderation, mobile-first, 8-35+ headcount",
+    "business-objectives": "5 objectives from BRD (OBJ-001 through OBJ-005)",
+    "stakeholders": "Scoutmaster, Asst Scoutmaster, SPL, Scouts, Parents",
+    "current-process": "7-step as-is process from BRD",
+    "future-process": "8-step to-be process from BRD",
+    "risks": "7 risks from BRD (RSK-001 through RSK-007)",
+    "dependencies": "Scouting America compliance, Azure Content Safety, Entra ID MSAL",
+    "data-requirements": "Recipe library, event data, feedback, shopping/equipment list state",
+    "design-direction": "Outdoor field guide aesthetic, forest green + campfire orange, Space Grotesk + Source Sans 3, shadcn/ui, mobile-first",
+    "performance-targets": "No hard numbers — responsive during meetings, fast enough not to frustrate scouts. Default Azure SWA uptime.",
+    "cicd-pipeline": "GitHub Actions: ci.yml (PR build+test), deploy.yml (push-to-main: SWA frontend + Functions API), infra.yml (manual Bicep dispatch)",
+    "monitoring": "Azure Application Insights for frontend and API",
+    "rollback": "Redeploy previous version from main — sufficient for MVP",
+    "test-coverage": "~70% API unit, key frontend component tests, one smoke e2e suite",
+    "content-moderation-testing": "Azure Content Safety sandbox tier for dev/test"
+  },
+  "referencesProcessed": [
+    {
+      "file": "docs/brds/scout-meal-planner-mvp-brd.md",
+      "status": "analyzed",
+      "timestamp": "2026-04-18T12:00:00Z",
+      "keyFindings": "27 business requirements across 7 categories, 5 objectives, 6 KPIs, 7 risks, 3 dependencies, as-is and to-be processes",
+      "integratedSections": ["executive-summary", "problem-definition", "users-personas", "scope", "functional-requirements", "risks", "dependencies", "metrics", "privacy-security"],
+      "conflicts": [],
+      "pendingActions": []
+    },
+    {
+      "file": "PRD.md",
+      "status": "analyzed",
+      "timestamp": "2026-04-18T12:00:00Z",
+      "keyFindings": "Design direction: colors (forest green, stone gray, earth brown, campfire orange), typography (Space Grotesk, Source Sans 3), animations, component selection (shadcn/ui), mobile patterns, spacing",
+      "integratedSections": ["product-overview-ux"],
+      "conflicts": [
+        "Old PRD includes offline/PWA and advanced search as in-scope; BRD places these out of scope",
+        "Old PRD does not mention dietary restrictions, content moderation, printable recipes, or emailable shopping lists"
+      ],
+      "pendingActions": []
+    }
+  ],
+  "nextActions": [],
+  "qualityChecks": [
+    "goals-defined",
+    "scope-clarified",
+    "functional-requirements-traced-to-brd",
+    "personas-defined",
+    "risks-documented",
+    "nfrs-defined",
+    "cicd-documented",
+    "operational-readiness-defined",
+    "instrumentation-plan-defined",
+    "rollout-phases-dated",
+    "feature-flags-defined",
+    "user-journeys-mapped",
+    "communication-plan-defined",
+    "troop-admin-frs-added",
+    "version-1.0-approved"
+  ],
+  "userPreferences": {
+    "detail-level": "comprehensive",
+    "question-style": "structured"
+  }
+}

--- a/.squad/squads/devteam/agents/backend/charter.md
+++ b/.squad/squads/devteam/agents/backend/charter.md
@@ -1,0 +1,31 @@
+# Backend
+
+## Role
+Backend Dev — APIs, database, infrastructure
+
+## Expertise
+- REST / GraphQL API design
+- Database schema & migrations
+- Authentication & authorization
+- Server-side validation & error handling
+- Performance tuning & caching
+
+## Style
+- Concise, production-grade code
+- Prefers convention over configuration
+- Writes inline comments only where non-obvious
+
+## What I Own
+- src/server/**
+- src/api/**
+- src/db/**
+- src/middleware/**
+
+## Boundaries
+- Does NOT touch UI components or styling
+- Escalates architecture-level changes to Lead
+
+## Collaboration
+- Reads decisions.md for shared context
+- Writes learnings to own history.md after each session
+- Defers to Tester for test strategy

--- a/.squad/squads/devteam/agents/backend/history.md
+++ b/.squad/squads/devteam/agents/backend/history.md
@@ -1,0 +1,12 @@
+# Backend History
+
+## Project Context
+- **Project:** scout-meal-planner
+- **Onboarded:** 2026-04-18
+- **Role:** Backend Dev
+
+## Learnings
+
+### 2026-04-18: Onboarded to scout-meal-planner
+- Joined the squad as Backend Dev
+- Initial project setup — reviewing codebase and establishing conventions

--- a/.squad/squads/devteam/agents/frontend/charter.md
+++ b/.squad/squads/devteam/agents/frontend/charter.md
@@ -1,0 +1,31 @@
+# Frontend
+
+## Role
+Frontend Dev — UI components, client-side logic
+
+## Expertise
+- Component architecture & state management
+- Responsive design & accessibility (a11y)
+- Client-side routing & navigation
+- CSS / design system integration
+- Browser API & performance
+
+## Style
+- Clean, composable components
+- Prefers small, focused files
+- Documents props and events
+
+## What I Own
+- src/components/**
+- src/pages/**
+- src/styles/**
+- src/hooks/**
+
+## Boundaries
+- Does NOT modify backend endpoints
+- Escalates API contract changes to Backend Dev / Lead
+
+## Collaboration
+- Reads decisions.md for design system decisions
+- Coordinates with Backend Dev on API contracts
+- Defers UI review to Lead or Designer

--- a/.squad/squads/devteam/agents/frontend/history.md
+++ b/.squad/squads/devteam/agents/frontend/history.md
@@ -1,0 +1,12 @@
+# Frontend History
+
+## Project Context
+- **Project:** scout-meal-planner
+- **Onboarded:** 2026-04-18
+- **Role:** Frontend Dev
+
+## Learnings
+
+### 2026-04-18: Onboarded to scout-meal-planner
+- Joined the squad as Frontend Dev
+- Initial project setup — reviewing codebase and establishing conventions

--- a/.squad/squads/devteam/agents/lead/charter.md
+++ b/.squad/squads/devteam/agents/lead/charter.md
@@ -1,0 +1,34 @@
+# Lead
+
+## Role
+Lead — Scope, decisions, code review
+
+## Expertise
+- Architecture decisions & trade-offs
+- Task decomposition & routing
+- Code review enforcement
+- Conflict resolution
+
+## Style
+- Brief, decisive communication
+- Asks clarifying questions before committing
+- Provides rationale with every decision
+
+## What I Own
+- .squad/decisions.md
+- .squad/routing.md
+- Architecture decision records
+
+## Boundaries
+- Does NOT generate domain artifacts (code, tests, docs)
+- Routes work to specialists
+- Reviews but does not rewrite
+
+## Collaboration
+- Reads decisions.md before every session
+- Writes to decisions/inbox/ for team-wide rulings
+- Enforces reviewer gates — rejected work goes to a different agent
+
+## Model
+- **Preferred:** (auto)
+- **Tier:** full

--- a/.squad/squads/devteam/agents/lead/history.md
+++ b/.squad/squads/devteam/agents/lead/history.md
@@ -1,0 +1,12 @@
+# Lead History
+
+## Project Context
+- **Project:** scout-meal-planner
+- **Onboarded:** 2026-04-18
+- **Role:** Coordinator
+
+## Learnings
+
+### 2026-04-18: Onboarded to scout-meal-planner
+- Joined the squad as Coordinator
+- Initial project setup — reviewing codebase and establishing conventions

--- a/.squad/squads/devteam/agents/ralph/charter.md
+++ b/.squad/squads/devteam/agents/ralph/charter.md
@@ -1,0 +1,24 @@
+# Ralph
+
+## Role
+Work Monitor — Backlog processing, status checks, auto-triage
+
+## Expertise
+- Issue triage & label management
+- Backlog prioritization
+- CI status monitoring
+- Stale work detection
+
+## Boundaries
+- Does NOT write code
+- Does NOT make architecture decisions
+- Surfaces issues — others resolve them
+
+## What I Own
+- Issue triage labels (squad:*)
+- Backlog status reports
+
+## Collaboration
+- Monitors open issues and PRs
+- Applies squad:{member} labels based on routing rules
+- Alerts Lead on blocked work or stale items

--- a/.squad/squads/devteam/agents/ralph/history.md
+++ b/.squad/squads/devteam/agents/ralph/history.md
@@ -1,0 +1,12 @@
+# Ralph History
+
+## Project Context
+- **Project:** scout-meal-planner
+- **Onboarded:** 2026-04-18
+- **Role:** Work Monitor
+
+## Learnings
+
+### 2026-04-18: Onboarded to scout-meal-planner
+- Joined the squad as Work Monitor
+- Initial project setup — reviewing codebase and establishing conventions

--- a/.squad/squads/devteam/agents/scribe/charter.md
+++ b/.squad/squads/devteam/agents/scribe/charter.md
@@ -1,0 +1,28 @@
+# Scribe
+
+## Role
+Session Logger — Memory, decisions, session logs (silent agent)
+
+## Expertise
+- Session summarization & knowledge capture
+- Decision merging from inbox/ to decisions.md
+- Conflict-free append patterns
+- History pruning & archival
+
+## What I Own
+- .squad/decisions.md (merge authority)
+- .squad/decisions/inbox/* (reads & merges)
+- .squad/log/* (session archives)
+- .squad/orchestration-log/* (spawn records)
+
+## Boundaries
+- SILENT — never speaks to the user directly
+- Does NOT make decisions — only records them
+- Does NOT write code
+- Merges decisions from inbox/ into decisions.md on commit
+
+## Memory Architecture
+- decisions.md — shared brain, all agents read this
+- decisions/inbox/ — agents drop decisions here in parallel
+- log/ — session history, searchable archive
+- agents/*/history.md — per-agent personal knowledge

--- a/.squad/squads/devteam/agents/scribe/history.md
+++ b/.squad/squads/devteam/agents/scribe/history.md
@@ -1,0 +1,12 @@
+# Scribe History
+
+## Project Context
+- **Project:** scout-meal-planner
+- **Onboarded:** 2026-04-18
+- **Role:** Session Logger
+
+## Learnings
+
+### 2026-04-18: Onboarded to scout-meal-planner
+- Joined the squad as Session Logger
+- Initial project setup — reviewing codebase and establishing conventions

--- a/.squad/squads/devteam/agents/tester/charter.md
+++ b/.squad/squads/devteam/agents/tester/charter.md
@@ -1,0 +1,32 @@
+# Tester
+
+## Role
+Tester — Tests, quality, edge cases
+
+## Expertise
+- Unit, integration, and E2E test strategy
+- Edge case identification & boundary testing
+- Test coverage analysis
+- CI pipeline configuration
+- Regression detection
+
+## Style
+- Thorough — finds corner cases others miss
+- Writes tests that explain intent
+- Reports bugs with reproduction steps
+
+## What I Own
+- tests/**
+- test/**
+- *.test.*
+- *.spec.*
+
+## Boundaries
+- Does NOT implement features — only tests them
+- Escalates systemic quality issues to Lead
+- Can reject work via reviewer protocol
+
+## Collaboration
+- Reviews PRs for test coverage
+- Writes test plans before implementation starts
+- Reports coverage gaps to Lead

--- a/.squad/squads/devteam/agents/tester/history.md
+++ b/.squad/squads/devteam/agents/tester/history.md
@@ -1,0 +1,12 @@
+# Tester History
+
+## Project Context
+- **Project:** scout-meal-planner
+- **Onboarded:** 2026-04-18
+- **Role:** Tester
+
+## Learnings
+
+### 2026-04-18: Onboarded to scout-meal-planner
+- Joined the squad as Tester
+- Initial project setup — reviewing codebase and establishing conventions

--- a/.squad/squads/devteam/casting/history.json
+++ b/.squad/squads/devteam/casting/history.json
@@ -1,0 +1,9 @@
+{
+  "events": [
+    {
+      "date": "2026-04-18T13:33:17.262Z",
+      "event": "Squad created",
+      "template": "fullstack"
+    }
+  ]
+}

--- a/.squad/squads/devteam/casting/policy.json
+++ b/.squad/squads/devteam/casting/policy.json
@@ -1,0 +1,8 @@
+{
+  "universe": "custom",
+  "description": "Agent naming and identity policy",
+  "rules": [
+    "Names should be descriptive of the role",
+    "Each agent has a unique identity"
+  ]
+}

--- a/.squad/squads/devteam/casting/registry.json
+++ b/.squad/squads/devteam/casting/registry.json
@@ -1,0 +1,34 @@
+{
+  "agents": [
+    {
+      "name": "Lead",
+      "role": "Coordinator",
+      "status": "✅ Active"
+    },
+    {
+      "name": "Backend",
+      "role": "Backend Dev",
+      "status": "✅ Active"
+    },
+    {
+      "name": "Frontend",
+      "role": "Frontend Dev",
+      "status": "✅ Active"
+    },
+    {
+      "name": "Tester",
+      "role": "Tester",
+      "status": "✅ Active"
+    },
+    {
+      "name": "Scribe",
+      "role": "Session Logger",
+      "status": "📋 Silent"
+    },
+    {
+      "name": "Ralph",
+      "role": "Work Monitor",
+      "status": "🔄 Monitor"
+    }
+  ]
+}

--- a/.squad/squads/devteam/ceremonies.md
+++ b/.squad/squads/devteam/ceremonies.md
@@ -1,0 +1,21 @@
+# Ceremonies
+
+## Standup
+- **Cadence:** Daily (or per-session)
+- **Format:** Each agent reports status, yesterday, today, blockers
+- **Output:** .squad/ceremonies/standup-{date}.md
+
+## Sprint Planning
+- **Cadence:** Start of each sprint/milestone
+- **Format:** Define sprint goal, assign tasks to agents
+- **Output:** .squad/ceremonies/sprint-planning-{date}.md
+
+## Retro
+- **Cadence:** End of sprint/milestone
+- **Format:** What went well, what to improve, action items
+- **Output:** .squad/ceremonies/retro-{date}.md
+
+## Design Review
+- **Cadence:** As needed for significant changes
+- **Format:** Present design, agents provide feedback, decision recorded
+- **Output:** .squad/ceremonies/design-review-{date}.md

--- a/.squad/squads/devteam/decisions.md
+++ b/.squad/squads/devteam/decisions.md
@@ -1,0 +1,3 @@
+# Decisions
+
+Shared brain for the team. All agents should read this before every session.

--- a/.squad/squads/devteam/routing.md
+++ b/.squad/squads/devteam/routing.md
@@ -1,0 +1,25 @@
+# Routing Rules
+
+## How Work Gets Assigned
+
+The coordinator reads this file to decide who handles each task.
+
+## Explicit Routes
+
+| Pattern | Agent | Reason |
+|---------|-------|--------|
+| api, server, database, auth, migration | Backend | Backend specialist |
+| ui, component, page, style, css, layout | Frontend | Frontend specialist |
+| test, spec, coverage, quality, bug | Tester | Testing specialist |
+
+## Domain Routes
+
+| Domain | Agent |
+|--------|-------|
+| feature | Frontend Dev (if UI), Backend Dev (if API) |
+| refactor | Original author of the code |
+| bug | Tester triages, specialist fixes |
+
+## Fallback
+
+Unmatched work goes to the Lead for triage.

--- a/.squad/squads/devteam/team.md
+++ b/.squad/squads/devteam/team.md
@@ -1,0 +1,18 @@
+# Full-Stack AI Team
+
+## Project Context
+- **Building:** Full-Stack Web Application
+- **Stack:** TypeScript, React, Node.js
+- **Lead:** You
+
+## Members
+
+| Name | Role | Charter | Status | Notes |
+|------|------|---------|--------|-------|
+| Lead | Coordinator | .squad/agents/lead/charter.md | ✅ Active | Scope, decisions, code review |
+| Backend | Backend Dev | .squad/agents/backend/charter.md | ✅ Active | APIs, database, server logic |
+| Frontend | Frontend Dev | .squad/agents/frontend/charter.md | ✅ Active | UI components, client-side |
+| Tester | Tester | .squad/agents/tester/charter.md | ✅ Active | Tests, quality, edge cases |
+| Scribe | Session Logger | .squad/agents/scribe/charter.md | 📋 Silent | Memory, decisions, session logs |
+| Ralph | Work Monitor | .squad/agents/ralph/charter.md | 🔄 Monitor | Backlog, triage, status |
+| @copilot | Coding Agent | — | ✅ Active | Code generation and pair programming |

--- a/docs/brds/scout-meal-planner-mvp-brd.md
+++ b/docs/brds/scout-meal-planner-mvp-brd.md
@@ -1,0 +1,331 @@
+---
+title: "Scout Meal Planner — MVP Launch"
+description: "Business requirements for launching the Scout Meal Planner with an initial pilot troop, addressing meal planning inefficiency, inconsistent record-keeping, and communication gaps."
+author: "andyrob"
+ms.date: "2026-04-18"
+ms.topic: "business-requirements-document"
+---
+
+# Scout Meal Planner — MVP Launch
+
+## Document Control
+
+| Field | Value |
+|---|---|
+| **Version** | 1.0 — Approved |
+| **Status** | Approved |
+| **Author** | andyrob |
+| **Date** | 2026-04-18 |
+| **Approvers** | andyrob |
+
+## Business Context and Background
+
+Scout troops plan meals for camping trips and multi-day events as part of regular troop meetings. Today this process relies on informal methods — verbal discussion, paper notes, and ad-hoc text messages — leading to lost information, duplicated effort, and preventable mistakes on trips. A purpose-built meal planning tool can streamline planning, improve communication between scouts, adult leaders, and parents, and free up meeting time for other troop activities.
+
+This initiative delivers a web-based meal planning application piloted with a single scout troop, with the potential to expand to additional troops.
+
+## Problem Statement and Business Drivers
+
+### Problem Statement
+
+Meal planning for scout trips consumes excessive meeting time, produces inconsistent records, and creates communication breakdowns between scouts and adult leadership. These problems result in incorrect food purchases, forgotten or wrong equipment, and reduced time available for other troop activities.
+
+### Business Drivers
+
+- **Operational efficiency** — Reduce time spent on meal planning during meetings so more time is available for other scouting activities.
+- **Accuracy** — Eliminate errors in food purchasing and equipment packing caused by inconsistent records.
+- **Communication** — Provide a single source of truth for meal plans accessible to scouts, leaders, and parents.
+- **Scalability** — Build a solution that can expand beyond the pilot troop to serve other troops.
+
+## Business Objectives and Success Metrics
+
+### Objectives
+
+| ID | Objective | Measure | Baseline | Target | Timeframe |
+|---|---|---|---|---|---|
+| OBJ-001 | Reduce meeting time spent on meal planning | Minutes per meeting devoted to meal planning | 30–60+ min | ≤15 min | By 3rd trip using the app |
+| OBJ-002 | Eliminate incorrect food purchases on trips | Trips with shopping errors or missing items | Most trips | Zero errors on routine trips | By 3rd trip using the app |
+| OBJ-003 | Ensure correct equipment is packed for each trip | Trips with forgotten or wrong equipment | Most trips | Zero forgotten equipment on routine trips | By 3rd trip using the app |
+| OBJ-004 | Ensure complete, accessible recipes on every trip | Trips with missing or incomplete recipe instructions | Most trips | All recipes accessible and complete at trip departure | By 2nd trip using the app |
+| OBJ-005 | Improve communication between scouts, leaders, and parents | Scoutmaster manual transcription steps eliminated | Manual transcription every trip | Shareable link replaces transcription | Launch |
+
+### Key Performance Indicators
+
+| KPI | Baseline | Target | Measurement Method |
+|---|---|---|---|
+| Meeting time on meal planning | 30–60+ min | ≤15 min | Scoutmaster observation per meeting |
+| Shopping list accuracy | Errors on most trips | Zero errors | Post-trip retrospective count |
+| Equipment list completeness | Items forgotten most trips | Zero omissions | Post-trip retrospective count |
+| Recipe availability on trip | Often incomplete or missing | 100% accessible | Spot-check at departure |
+| User adoption rate (pilot troop) | 0% | 80% of active scouts | Unique logins per planning cycle |
+| Post-trip feedback submission rate | Informal, in-person only | ≥50% of attendees submit feedback | In-app feedback count vs. trip roster |
+
+## Stakeholders and Roles
+
+| Stakeholder | Role | Interest | Impact Level |
+|---|---|---|---|
+| Scoutmaster | Sponsor / Oversight | Reduce meeting overhead, ensure trip readiness, transcribe and communicate plans to parents | High |
+| Assistant Scoutmaster | Oversight | Support planning, oversee scout participation | High |
+| Senior Patrol Leader (SPL) | Planning lead | Facilitates meal planning during meetings, coordinates patrols | High |
+| Scouts | Primary users | Plan meals, shop for ingredients, cook, record feedback | High |
+| Parents of Scouts | Secondary users | Visibility into meal plans, support purchasing and logistics | Medium |
+
+## Scope
+
+### In Scope
+
+The MVP delivers the core meal planning workflow for a single troop:
+
+- **Event creation** — Create a trip/event with dates, departure/return times, and logistical context (cabin vs. tent, power/water availability, altitude, trailer access, hiking trip).
+- **Meal scheduling** — Define meals per day (breakfast, lunch, dinner, snacks) with parameters: trailside, time-constrained, multi-course, headcount (scouts + adults + guests).
+- **Meal selection recording** — SPL or designated scout records the decided meals (app does not need to facilitate brainstorming or voting).
+- **Recipe and ingredient management** — Capture ingredients with quantities, step-by-step cooking instructions, cooking method, and required equipment (pots, pans, utensils, spices/condiments).
+- **Equipment list generation** — Consolidated equipment list for the event derived from assigned recipes.
+- **Shopping list generation** — Consolidated list with quantities and estimated prices, divided by meal. Emailable to assigned shoppers.
+- **Printable recipes** — Recipes can be printed for use on the trip.
+- **Plan sharing** — Shareable link for parents and stakeholders (no login required to view).
+- **Recipe library** — Save and reuse recipes across events.
+- **Post-trip feedback** — Scouts submit feedback on meals after the trip (portions, taste, equipment issues, reuse recommendations).
+- **Content moderation** — User-generated text scanned for inappropriate content.
+- **Authentication and roles** — Scoutmaster, leaders, and scouts have appropriate access levels.
+
+### Out of Scope (Post-MVP)
+
+- Multi-troop support and cross-troop recipe sharing.
+- Patrol management within the app (creating patrols, assigning scouts to patrols).
+- In-app brainstorming and voting for meal selection.
+- Individual scout shopper assignment within the app.
+- Advanced filtering, favorites, and search.
+- Advanced feedback analytics.
+- Budget tracking and purchase receipt capture.
+- Offline-first / progressive web app capabilities.
+- Native mobile app (iPhone / Android).
+- Integration with external shopping or calendar services.
+
+### Assumptions
+
+- Scouts and leaders have access to a web browser on phone or computer.
+- The pilot troop has 3 patrols (typical structure).
+- Internet access is available during planning meetings (not required on the trip itself).
+- The Scoutmaster currently transcribes and forwards plans manually; the app replaces this step.
+
+### Constraints
+
+- **Prototype by May 2026** — A working prototype must be available for demonstration and early feedback.
+- **Live by September 2026** — The application must be production-ready for the fall camping season.
+- **Single developer** — The application is built and maintained by a single developer.
+- **Youth safety and PII** — Minimize personally identifiable information stored for scouts (minors). No collection of email, phone, or address for youth members without guardian consent. Dietary restrictions are recorded at the meal level, never linked to individual people, as this is considered sensitive information.
+- **Scouting America compliance** — The application must comply with Scouting America technology platform requirements for youth-facing applications. This includes communication guidelines and appropriate content safeguards. A compliance review is required before scouts access the app.
+- **Content moderation** — User-generated text (feedback, notes, recipe names) must be scanned for offensive, abusive, or inappropriate language using a content moderation service (e.g., Azure Content Safety).
+- **Mobile-first web** — Scouts primarily use phones (iPhone and Android). The web app must be fully functional on mobile browsers. Native app is a stretch goal, not an MVP requirement.
+- **Trip headcount range** — The system must support groups of 8–35+ people (scouts, adults, and occasional guests).
+
+## Business Requirements
+
+### Event Management
+
+| ID | Requirement | Linked Objective | Priority | Acceptance Criteria |
+|---|---|---|---|---|
+| BR-001 | A user can create an event with a name, date range, departure time, return time, and expected headcount (scouts, adults, guests). | OBJ-001 | Must | Event is persisted with all fields. Date range, times, and headcount are editable after creation. |
+| BR-002 | A user can capture trip logistics on an event: camping type (tent/cabin), power availability, running water, trailer access, hiking trip, cooking at altitude, and expected weather. | OBJ-002, OBJ-003 | Must | Logistics fields are visible when planning meals and selecting recipes. |
+| BR-003 | A user can define meals for each day of the event: breakfast, lunch, dinner, and snacks. | OBJ-001 | Must | Each day in the date range shows meal slots. Meals can be added and removed. |
+| BR-004 | A user can mark a meal as trailside (must be prepared in advance) or time-constrained. | OBJ-002 | Should | Trailside and time-constraint flags are visible on the meal and in the schedule view. |
+| BR-005 | A user can indicate that a meal has multiple courses (e.g., dinner with dessert). | OBJ-002 | Should | Multiple recipes can be assigned to a single meal slot. |
+| BR-027 | A user can record dietary restrictions or considerations for a meal (e.g., nut allergy, vegetarian option needed). Restrictions are captured at the meal level, not linked to individual people. | OBJ-002 | Must | Dietary notes are visible on the meal in the schedule view and when selecting recipes. No dietary information is associated with a specific person. |
+
+### Recipe Management
+
+| ID | Requirement | Linked Objective | Priority | Acceptance Criteria |
+|---|---|---|---|---|
+| BR-006 | A user can create a recipe with a name, ingredient list (item, quantity, unit), step-by-step cooking instructions, and cooking method. | OBJ-002, OBJ-004 | Must | Recipe is saved to the library. All fields are editable. |
+| BR-007 | A user can specify equipment required for a recipe: pots, pans, utensils, and supplemental items (spices, condiments) not listed as ingredients. | OBJ-003 | Must | Equipment items are stored with the recipe and appear on the event equipment list. |
+| BR-008 | A user can assign a recipe from the library to a meal slot on an event. | OBJ-001, OBJ-002 | Must | Assigned recipe's ingredients and equipment flow into the event's shopping and equipment lists. |
+| BR-009 | A user can save a recipe to the troop recipe library for reuse across events. | OBJ-001 | Must | Previously saved recipes are searchable and selectable when assigning to a meal. |
+| BR-010 | Recipes can be scaled by headcount so ingredient quantities adjust proportionally. | OBJ-002 | Must | When headcount changes, ingredient quantities recalculate. Fractions display as practical cooking measurements. |
+| BR-011 | A user can print a recipe in a format suitable for use on a trip (ingredients, instructions, equipment on one page). | OBJ-004 | Must | Browser print produces a clean, readable single-recipe printout. |
+
+### Shopping List
+
+| ID | Requirement | Linked Objective | Priority | Acceptance Criteria |
+|---|---|---|---|---|
+| BR-012 | The system generates a consolidated shopping list for an event from all assigned recipes, scaled to headcount. | OBJ-002 | Must | Duplicate ingredients across recipes are combined with summed quantities. List updates when meals or headcount change. |
+| BR-013 | The shopping list displays estimated price per item when provided. | OBJ-002 | Should | Price column appears on the list. Total estimated cost is shown. |
+| BR-014 | A user can email the shopping list (or a portion of it) to a specified email address. | OBJ-005 | Must | Email is sent with a readable shopping list. Recipient does not need an account. |
+| BR-015 | Shopping list items can be checked off as purchased. | OBJ-002 | Should | Checked state persists across sessions. |
+
+### Equipment List
+
+| ID | Requirement | Linked Objective | Priority | Acceptance Criteria |
+|---|---|---|---|---|
+| BR-016 | The system generates a consolidated equipment list for an event from all assigned recipes. | OBJ-003 | Must | Duplicate equipment items are consolidated. List updates when meal assignments change. |
+| BR-017 | Equipment list items can be checked off as packed. | OBJ-003 | Should | Checked state persists across sessions. |
+
+### Plan Sharing
+
+| ID | Requirement | Linked Objective | Priority | Acceptance Criteria |
+|---|---|---|---|---|
+| BR-018 | A user can generate a shareable read-only link to the event plan (schedule, recipes, shopping list, equipment list). | OBJ-005 | Must | Link is accessible without login. Displays current plan state. |
+
+### Feedback
+
+| ID | Requirement | Linked Objective | Priority | Acceptance Criteria |
+|---|---|---|---|---|
+| BR-019 | After a trip, scouts can submit structured feedback on each meal: rating, portion assessment (too much / just right / too little), and free-text comments. | OBJ-004 | Must | Feedback is linked to the specific meal and recipe. Multiple scouts can submit feedback for the same meal. |
+| BR-020 | Feedback history is visible on a recipe in the library so planners can see past ratings and comments when selecting recipes for future events. | OBJ-001, OBJ-004 | Must | Recipe detail view shows aggregated ratings and individual comments from past events. |
+| BR-021 | Feedback can be submitted at any time after the event ends, not only at the next meeting. | OBJ-004 | Must | Feedback form is available from the event detail as soon as the event end date passes. |
+
+### Safety and Compliance
+
+| ID | Requirement | Linked Objective | Priority | Acceptance Criteria |
+|---|---|---|---|---|
+| BR-022 | All user-generated text (recipe names, instructions, notes, feedback) is scanned by a content moderation service before being stored or displayed. | Compliance | Must | Offensive or inappropriate content is flagged and not displayed. Flagged content is reviewable by the Scoutmaster. |
+| BR-023 | The application stores only first names for youth members. No email, phone, or address is collected for minors without guardian consent. | Compliance | Must | Account creation for youth accounts does not require or store PII beyond first name and authentication token. |
+| BR-024 | Scoutmaster has administrative access to review flagged content and manage troop membership. | Compliance | Must | Admin view shows flagged items. Scoutmaster can approve, edit, or remove content. |
+
+### Authentication
+
+| ID | Requirement | Linked Objective | Priority | Acceptance Criteria |
+|---|---|---|---|---|
+| BR-025 | Users authenticate via Microsoft Entra ID (consumer accounts). | Compliance | Must | Login flow completes via MSAL. Session persists across browser refreshes. |
+| BR-026 | Role-based access: Scoutmaster (admin), Leader (edit), Scout (edit assigned, submit feedback), Parent (read-only via shared link). | Compliance | Must | Each role sees only permitted actions. Unauthorized actions are rejected by the API. |
+
+## Current and Future Business Processes
+
+### Current State (As-Is)
+
+Meal planning occurs during troop meetings, led by the Senior Patrol Leader (SPL) or a senior scout, with oversight from the Scoutmaster or Assistant Scoutmaster.
+
+**Step 1 — Trip logistics briefing.** The group discusses trip parameters:
+
+- Departure and return times.
+- Camping type (tent or cabin).
+- Available infrastructure (power, running water, trailer access).
+- Trip type (hiking, car camping) and whether cooking at altitude.
+- Expected weather conditions.
+
+**Step 2 — Meal list and parameters.** The group identifies which meals are needed:
+
+- Breakfast, lunch, dinner, and snacks for each day.
+- Some meals may have multiple courses (e.g., dinner with dessert).
+- Trailside meals must be prepared in advance.
+- Time-constrained meals (e.g., fast breakfast before breaking camp).
+- Headcount: scouts plus adults plus guests.
+
+**Step 3 — Brainstorm and vote.** Scouts brainstorm meal ideas and vote on selections for each meal slot.
+
+**Step 4 — Patrol planning.** The troop splits into patrols (typically three). Each patrol is assigned responsibility for a subset of meals and must produce:
+
+- Ingredient list with quantities.
+- Equipment list (cooking method, pots, pans, utensils, spices/condiments).
+- Step-by-step cooking instructions.
+- Shopping list with items, quantities, and estimated prices.
+- Shopping assignments — each meal's shopping list is assigned to an individual scout.
+
+**Step 5 — Handoff to Scoutmaster.** Patrol plans are given to the Scoutmaster, who manually transcribes them and sends the consolidated plan to parents.
+
+**Step 6 — Shopping and packing.** Assigned scouts purchase ingredients. All ingredients are brought to the trip departure point for packing.
+
+**Step 7 — Post-trip retrospective.** At the next troop meeting, scouts discuss what went well and what didn't, including meal feedback.
+
+**Known pain points in the current process:**
+
+- Recording is inconsistent — some patrols use paper, some use phones, some rely on memory.
+- The Scoutmaster transcription step is manual and error-prone.
+- Feedback happens at the next meeting; scouts who attended the trip may be absent, and details are forgotten by then.
+- No reusable record of recipes — the same planning effort repeats for similar meals.
+- Equipment is frequently forgotten because lists are incomplete or lost.
+
+### Future State (To-Be)
+
+The Scout Meal Planner replaces informal, manual processes with a structured digital workflow while preserving the scout-led planning culture.
+
+**Step 1 — Event setup (SPL or Scoutmaster, in-app).** Create the event with dates, times, headcount, and trip logistics. This replaces the verbal logistics briefing with a persistent, shared record.
+
+**Step 2 — Meal schedule (SPL, in-app).** Define meal slots for each day. Mark trailside or time-constrained meals. This replaces ad-hoc meal listing on paper.
+
+**Step 3 — Meal decisions (meeting, recorded in-app).** The troop discusses and decides meals as they do today. The SPL records the selected meals and assigns recipes from the library or creates new ones. Brainstorming and voting remain in-person activities.
+
+**Step 4 — Recipe detail (designated scouts, in-app).** Scouts enter or refine recipes: ingredients, quantities, cooking instructions, cooking method, and equipment. Previously used recipes are pulled from the library and adjusted. This replaces inconsistent paper/phone notes with a single structured record.
+
+**Step 5 — Review and share (Scoutmaster, in-app).** The Scoutmaster reviews the consolidated plan — schedule, shopping list, equipment list — and shares a read-only link with parents. This eliminates manual transcription.
+
+**Step 6 — Shopping (scouts, email from app).** Shopping lists are emailed to assigned scouts. Scouts check off items as purchased. This replaces handwritten or verbal shopping assignments.
+
+**Step 7 — Trip execution (all, printed recipes).** Recipes are printed before departure. Scouts and leaders reference printed recipes while cooking. Equipment checklist is used during packing.
+
+**Step 8 — Feedback (scouts, in-app, anytime after trip).** Scouts submit meal feedback directly in the app at any time after the event ends — no need to wait for the next meeting. Feedback is attached to the recipe for future planning.
+
+**Key improvements over current state:**
+
+- Single source of truth replaces scattered notes and verbal plans.
+- Scoutmaster transcription step eliminated.
+- Recipes accumulate feedback and are reused, reducing repeat planning effort.
+- Shopping and equipment lists are generated automatically, reducing errors.
+- Feedback is captured while memories are fresh, not deferred to the next meeting.
+
+## Data and Reporting Requirements
+
+- **Recipe library** — Persistent store of recipes with ingredients, instructions, equipment, and cooking method. Recipes are reusable across events.
+- **Event data** — Events with dates, logistics, meal schedule, recipe assignments, headcount, and status (planning / active / completed).
+- **Feedback data** — Structured ratings and free-text comments linked to meals and recipes.
+- **Shopping list state** — Generated list with purchase check-off state per item.
+- **Equipment list state** — Generated list with packing check-off state per item.
+- **No reporting dashboards required for MVP.** Feedback history displayed inline on recipe detail is sufficient.
+
+## Benefits and High-Level Economics
+
+### Quantitative Benefits
+
+- **Meeting time recovered** — Estimated 15–45 minutes per planning meeting redirected to other troop activities.
+- **Error reduction** — Fewer incorrect purchases and forgotten equipment items per trip (target: zero on routine trips).
+- **Feedback capture rate** — Move from informal, often-lost verbal feedback to structured, persistent records.
+
+### Qualitative Benefits
+
+- **Scout ownership** — Digital tool reinforces scout-led planning while providing structure.
+- **Parent confidence** — Shared link gives parents visibility into meal plans without adding work for the Scoutmaster.
+- **Institutional knowledge** — Recipe library preserves troop cooking knowledge across scout generations.
+- **Reduced Scoutmaster burden** — Eliminates manual transcription and reduces coordination overhead.
+
+### Cost Considerations
+
+- **Hosting** — Azure Static Web App (free tier may suffice for pilot) plus Azure Functions consumption plan.
+- **Database** — Azure Cosmos DB (free tier for pilot; monitor RU consumption as troop count grows).
+- **Content moderation** — Azure Content Safety service (pay-per-call; low volume during pilot).
+- **Authentication** — Microsoft Entra ID (free for consumer accounts via MSAL).
+- **Developer time** — Single developer; primary cost is opportunity cost of time.
+
+## Risks and Mitigations
+
+| ID | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| RSK-001 | Scouting America compliance requirements block youth access to the app | High | High | Research Scouting America technology platform policies early (before prototype). Design for compliance from the start. Engage council-level contacts for guidance. |
+| RSK-002 | Content moderation fails to catch inappropriate content | Medium | High | Integrate Azure Content Safety or equivalent service. Review flagged content manually during pilot. Implement reporting mechanism. |
+| RSK-003 | Low scout adoption — scouts revert to informal methods | Medium | High | Involve SPL and senior scouts in design feedback. Ensure mobile experience is fast and intuitive. Demonstrate value on first trip. |
+| RSK-004 | Single developer bottleneck delays September launch | Medium | Medium | Prioritize MVP features ruthlessly. Use existing component libraries (shadcn/ui). Accept rough edges in non-critical areas for launch. |
+| RSK-005 | Poor mobile experience degrades usability during meetings | Medium | Medium | Mobile-first design and testing. Test on actual scout devices during prototype phase. |
+| RSK-006 | Feedback is still not captured because scouts forget or skip it | Low | Medium | Enable in-app feedback immediately after the trip (push notification or reminder). Allow feedback from the field, not just at the next meeting. |
+| RSK-007 | PII exposure for minor scouts | Low | High | Store only first names for youth. No email/phone collection for minors without guardian consent. Implement access controls and data retention policies. |
+
+## Dependencies
+
+| ID | Dependency | Owner | Status | Impact if Delayed |
+|---|---|---|---|---|
+| DEP-001 | Scouting America technology platform compliance review | Scoutmaster / Council | Not started | Blocks youth access to the app; adults-only workaround possible |
+| DEP-002 | Content moderation service (Azure Content Safety or equivalent) | Developer | Not started | Blocks user-generated content features or requires manual review |
+| DEP-003 | Microsoft Entra ID authentication (consumer accounts) | Developer | In progress | Blocks multi-user access and role-based permissions |
+
+## Glossary
+
+| Term | Definition |
+|---|---|
+| Troop | A local unit of scouts led by adult volunteers |
+| Scoutmaster | The primary adult leader responsible for a troop |
+| Assistant Scoutmaster | An adult leader who supports the Scoutmaster |
+| Senior Patrol Leader (SPL) | The elected youth leader of the troop who facilitates meetings and planning |
+| Patrol | A small group of scouts within a troop (typically 6–8 scouts) |
+| Event | A camping trip or multi-day activity requiring meal planning |
+| Trailside meal | A meal that must be prepared in advance because cooking on-site is not feasible |
+| Headcount | The total number of people to feed: scouts + adults + guests |
+| Scouting America | The national organization governing scout troops in the United States |
+| Content moderation | Automated scanning of user-generated text for offensive, abusive, or inappropriate language |

--- a/docs/policies/privacy-policy.md
+++ b/docs/policies/privacy-policy.md
@@ -1,0 +1,127 @@
+<!-- markdownlint-disable-file -->
+<!-- markdown-table-prettify-ignore-start -->
+# Scout Meal Planner — Privacy Policy & Data Handling Reference
+
+Version 1.0 | Effective 2026-04-18 | Owner: andyrob
+
+> This document serves two purposes: (1) user-facing privacy policy for the Scout Meal Planner application, and (2) decision reference for developers and agents working on the codebase. When making implementation decisions about data collection, storage, or sharing, consult this policy.
+
+## 1. What We Collect
+
+| Data Category | What | Who | Why | Stored Where |
+|--------------|------|-----|-----|-------------|
+| Authentication token | Microsoft Entra ID token (OAuth) | All users | Verify identity | In-memory only (not persisted) |
+| Display name | First name (youth) or full name (adults) | All members | Identify members in troop context | Cosmos DB `members` container |
+| Email address | Microsoft account email | Adult members only | Account recovery, admin contact | Cosmos DB `members` container |
+| Role & status | Troop role, membership status | All members | Access control (RBAC) | Cosmos DB `members` container |
+| Event data | Event names, dates, meal schedules | Created by leaders/SPL | Meal planning | Cosmos DB `events` container |
+| Recipe data | Recipe names, ingredients, instructions, equipment | Created by leaders/scouts | Recipe library | Cosmos DB `recipes` container |
+| Feedback | Star ratings, portion assessment, free-text comments, photos | Submitted by scouts | Post-trip improvement | Cosmos DB `feedback` container |
+| Dietary notes | Meal-level dietary restrictions | Entered by leaders | Meal planning safety | Embedded in event meal records |
+
+### What We Do NOT Collect
+* Email addresses for youth members (under 18).
+* Phone numbers, home addresses, or GPS location for any user.
+* Browsing history, cookies for tracking, or advertising identifiers.
+* Individual-linked dietary or medical information — dietary notes are at the meal level only, never associated with a specific person.
+* Payment or financial information.
+
+## 2. Why We Collect It
+
+All data collected serves one of these purposes:
+1. **Authentication and access control** — verify identity and enforce role-based permissions.
+2. **Meal planning functionality** — events, recipes, shopping lists, equipment lists.
+3. **Post-trip improvement** — feedback to improve future meal plans.
+4. **Troop administration** — member management, invitations, role assignments.
+
+We do not use data for advertising, marketing, analytics beyond basic application health monitoring (Azure Application Insights), or any purpose unrelated to troop meal planning.
+
+## 3. How We Store and Protect Data
+
+| Control | Implementation |
+|---------|---------------|
+| Encryption at rest | Azure Cosmos DB default encryption (AES-256) |
+| Encryption in transit | HTTPS enforced via Azure Static Web Apps |
+| Authentication | Microsoft Entra ID (OAuth 2.0 / OIDC) |
+| Authorization | Role-based access control — API enforces permission checks on every request |
+| Data isolation | All troop data partitioned by `troopId` — one troop cannot access another's data |
+| Content moderation | User-generated text scanned before storage (Azure Content Safety) |
+| Infrastructure | Azure Static Web Apps + Azure Functions (managed, patched by Microsoft) |
+
+## 4. Who Can Access Data
+
+| Role | Can Access | Cannot Access |
+|------|-----------|--------------|
+| Troop Admin (Scoutmaster) | All troop data, member management, flagged content review, data deletion | Other troops' data |
+| Adult Leader | Events, recipes, feedback, shopping/equipment lists | Member management, flagged content |
+| Senior Patrol Leader | Events, recipes, feedback, shopping/equipment lists | Member management, flagged content |
+| Patrol Leader | Events, recipes, feedback (own), shopping/equipment lists | Other scouts' feedback, member management |
+| Scout | Events, recipes, own feedback, shopping/equipment lists | Other scouts' feedback, member management |
+| Parent (via shared link) | Read-only event plan (schedule, recipes, shopping list, equipment) | Feedback, member data, admin functions |
+
+## 5. Data Retention
+
+| Data Type | Retention | Deletion Trigger |
+|-----------|----------|-----------------|
+| Member records | Until member removed by admin or deletion requested | Admin action or parental request |
+| Event data | Indefinite (historical reference for future planning) | Admin deletes event |
+| Recipes | Indefinite (troop library asset) | Admin deletes recipe |
+| Feedback | Indefinite (tied to recipe improvement) | Admin deletes, or member data deletion request |
+| Authentication tokens | Session-scoped (not persisted) | Browser session ends |
+
+## 6. Children's Privacy (COPPA)
+
+Scout Meal Planner is designed for use by scout troops, which include members under 13. We comply with COPPA through the following controls:
+
+1. **Minimal data collection for youth**: Only first name and authentication token. No email, phone, or address.
+2. **Parental consent via Microsoft Family accounts**: Scouts under 13 must use a Microsoft account managed by a parent/guardian. Microsoft's family consent flow satisfies COPPA's verifiable parental consent requirement at account creation.
+3. **Consent notice at join**: When a scout joins a troop via invite code, the app displays: *"By joining, a parent/guardian confirms they consent to data collection as described in our privacy policy."* The invite code is distributed by the troop leader to parents, establishing an offline consent chain.
+4. **Parental rights**:
+   * **Review**: Parents can request a summary of their child's data by contacting the troop admin.
+   * **Delete**: Parents can request deletion of all their child's data. The troop admin executes this via the member data deletion function (FR-031). Feedback from deleted members is either anonymized or removed.
+   * **Refuse further collection**: Parents can revoke their child's Microsoft account access at any time, which immediately prevents further data collection.
+5. **Content moderation**: All user-generated text (including from youth) is scanned by Azure Content Safety before storage.
+
+## 7. Data Sharing
+
+We do not share data with third parties. Data flows only to:
+* **Azure services** (Cosmos DB, Static Web Apps, Functions, Content Safety, Application Insights) — Microsoft is the infrastructure provider, governed by Microsoft's data processing agreements.
+* **Shareable read-only links** — event plans accessible without login. These contain no PII (no member names, emails, or feedback). Links can be regenerated or revoked by the troop admin.
+
+## 8. Data Deletion
+
+### Member data deletion (FR-031)
+Troop admins can delete all data associated with a specific member. This removes or anonymizes:
+* Member record (name, role, status)
+* Feedback submitted by the member
+* Audit trail entries attributable to the member
+
+### Account deletion
+Users can delete their Microsoft account independently. This revokes authentication but does not automatically remove troop data. A separate data deletion request to the troop admin is required.
+
+### Requesting deletion
+For the MVP pilot, contact the troop admin directly or email a deletion request via the link in the application footer.
+
+## 9. Agent & Developer Decision Reference
+
+When building features, apply these rules:
+
+| Principle | Rule | Example |
+|-----------|------|---------|
+| Data minimization | Do not add new PII fields without updating this policy and confirming COPPA compliance | Adding "last name" to youth profiles would violate policy |
+| Youth safety | Never link dietary restrictions, medical info, or allergies to a specific person | Dietary notes go on the meal, not the member |
+| Consent chain | Any new data collection from youth requires reviewing the consent model in PRD Section 11 | Adding photo uploads from scouts needs consent review |
+| Sharing scope | Shareable links must never expose PII, feedback text, or member information | Shopping list: OK. Feedback comments: not OK |
+| Deletion completeness | Any new data type that references a `userId` or `memberId` must be included in the FR-031 deletion cascade | New "assignments" container would need deletion support |
+| Content moderation | All free-text input from any user must pass through content moderation before storage | Recipe names, feedback comments, event descriptions |
+| Audit trail | When anonymizing deleted member data, replace identifiable info with a placeholder (e.g., "Deleted Member") rather than removing the record entirely | Preserves event history integrity |
+
+## 10. Changes to This Policy
+
+Changes to this policy are tracked in the changelog below and referenced in the PRD.
+
+| Version | Date | Summary |
+|---------|------|---------|
+| 1.0 | 2026-04-18 | Initial privacy policy — data inventory, COPPA model, retention, agent decision reference |
+
+<!-- markdown-table-prettify-ignore-end -->

--- a/docs/prds/scout-meal-planner-mvp.md
+++ b/docs/prds/scout-meal-planner-mvp.md
@@ -1,0 +1,465 @@
+<!-- markdownlint-disable-file -->
+<!-- markdown-table-prettify-ignore-start -->
+# Scout Meal Planner MVP — Product Requirements Document (PRD)
+Version 1.0 | Status Approved | Owner andyrob | Team Solo Developer | Target September 2026 | Lifecycle MVP
+
+## Progress Tracker
+| Phase | Done | Gaps | Updated |
+|-------|------|------|---------|
+| Context | Yes | None | 2026-04-18 |
+| Problem & Users | Yes | None | 2026-04-18 |
+| Scope | Yes | None | 2026-04-18 |
+| Requirements | Yes | None | 2026-04-18 |
+| Metrics & Risks | Yes | None | 2026-04-18 |
+| Operationalization | Yes | None | 2026-04-18 |
+| Finalization | Yes | None | 2026-04-18 |
+Unresolved Critical Questions: 2 | TBDs: 0
+
+## 1. Executive Summary
+### Context
+Scout troops plan meals for camping trips as part of regular troop meetings. Today this process relies on informal methods — verbal discussion, paper notes, and ad-hoc text messages — leading to lost information, duplicated effort, and preventable mistakes on trips. This initiative delivers a web-based meal planning application piloted with a single scout troop.
+
+### Core Opportunity
+Replace informal, error-prone meal planning with a structured digital tool that preserves scout-led planning culture while eliminating manual transcription, lost records, and communication breakdowns between scouts, leaders, and parents.
+
+### Goals
+| Goal ID | Statement | Type | Baseline | Target | Timeframe | Priority |
+|---------|-----------|------|----------|--------|-----------|----------|
+| G-001 | Reduce meeting time spent on meal planning | Efficiency | 30–60+ min per meeting | ≤15 min per meeting | By 3rd trip using the app | Must |
+| G-002 | Eliminate incorrect food purchases on trips | Accuracy | Errors on most trips | Zero errors on routine trips | By 3rd trip using the app | Must |
+| G-003 | Ensure correct equipment is packed for each trip | Accuracy | Items forgotten most trips | Zero forgotten equipment | By 3rd trip using the app | Must |
+| G-004 | Ensure complete, accessible recipes on every trip | Completeness | Often incomplete or missing | 100% accessible at departure | By 2nd trip using the app | Must |
+| G-005 | Improve communication between scouts, leaders, and parents | Communication | Manual transcription every trip | Shareable link replaces transcription | Launch | Must |
+
+### Objectives (Optional)
+| Objective | Key Result | Priority | Owner |
+|-----------|------------|----------|-------|
+| Working prototype for early feedback | Demo-ready by May 2026 | Must | andyrob |
+| Production-ready for fall camping season | Live by September 2026 | Must | andyrob |
+| Pilot troop adoption | 80% of active scouts logging in per planning cycle | Must | andyrob + Scoutmaster |
+
+## 2. Problem Definition
+### Current Situation
+Meal planning occurs during troop meetings, led by the Senior Patrol Leader (SPL) with Scoutmaster oversight. The process involves verbal logistics briefing, brainstorming meal ideas, splitting into patrols to plan details, handoff to Scoutmaster for manual transcription, shopping, and post-trip retrospective. Recording is inconsistent (paper, phones, memory). The Scoutmaster transcription step is manual and error-prone. Feedback happens at the next meeting when details are forgotten. No reusable recipe records exist.
+
+### Problem Statement
+Meal planning for scout trips consumes excessive meeting time, produces inconsistent records, and creates communication breakdowns between scouts and adult leadership. These problems result in incorrect food purchases, forgotten or wrong equipment, and reduced time available for other troop activities.
+
+### Root Causes
+* Recording methods are inconsistent — some patrols use paper, some use phones, some rely on memory.
+* No single source of truth — plans are scattered across notes, texts, and verbal agreements.
+* Manual transcription by Scoutmaster is error-prone and time-consuming.
+* No persistent recipe library — the same planning effort repeats for similar meals.
+* Feedback is deferred to the next meeting, when attendees may be absent and details forgotten.
+* Equipment lists are incomplete or lost between planning and packing.
+
+### Impact of Inaction
+Continued meeting time waste (30–60+ min per trip), repeated shopping errors, forgotten equipment on trips, lost institutional cooking knowledge as scouts age out, and ongoing Scoutmaster burden from manual transcription.
+
+## 3. Users & Personas
+| Persona | Goals | Pain Points | Impact |
+|---------|-------|------------|--------|
+| Senior Patrol Leader (SPL) | Efficiently lead meal planning, record decisions, coordinate patrols | Spends too long on planning, records get lost, has to repeat work | High — primary user for planning workflow |
+| Scoutmaster | Reduce meeting overhead, ensure trip readiness, communicate plans to parents | Manual transcription, chasing down incomplete plans, no visibility until handoff | High — admin/oversight role |
+| Scout (general) | Plan meals, shop for ingredients, cook on trip, give feedback | Inconsistent records, forgotten equipment, feedback not captured | High — hands-on user |
+| Assistant Scoutmaster | Support planning, oversee scout participation | Duplicated oversight effort, no shared view of plan status | High — supporting role |
+| Parent | Visibility into meal plans, support purchasing and logistics | No access to plans without Scoutmaster forwarding | Medium — read-only consumer via shared link |
+
+### Journeys
+
+#### Journey 1: SPL Plans a Camping Trip (Primary Planning Flow)
+
+| Step | Action | Screen / Component | Feeling | Pain Point Addressed |
+|------|--------|-------------------|---------|---------------------|
+| 1 | SPL opens app on phone during troop meeting | Home / Event list | "Let’s get this done quickly" | Meetings run long on meal planning |
+| 2 | Creates new event: name, dates, headcount, logistics | Create Event dialog | Focused — quick structured form | Replaces verbal briefing and scattered notes |
+| 3 | Defines meal slots for each day (B/L/D/snacks), marks trailside or time-constrained | Event Schedule view | Organized — sees the whole trip at a glance | No more forgotten meal slots |
+| 4 | Adds dietary notes to meals as discussed | Meal detail | Confident — restrictions recorded without naming individuals | Sensitive info stays at meal level |
+| 5 | Browses recipe library, assigns recipes to meals (or creates new ones) | Recipe Library + Assign dialog | Efficient — reuses past recipes | Eliminates re-planning the same meals from scratch |
+| 6 | Reviews auto-generated shopping list and equipment list | Shopping List / Equipment List tabs | Relieved — consolidated and scaled automatically | No more manual tallying and missed items |
+| 7 | Emails shopping list to assigned scout shoppers | Email dialog | Done — shopping delegated in one tap | Replaces verbal assignments that get forgotten |
+| 8 | Scoutmaster reviews and shares read-only link with parents | Shareable Link action | Satisfied — no more manual transcription | Eliminates the Scoutmaster bottleneck |
+| 9 | Scouts print recipes before departure | Print Recipe action | Prepared — recipes in hand for the trip | No more missing or incomplete instructions on-site |
+
+#### Journey 2: Scout Submits Post-Trip Feedback
+
+| Step | Action | Screen / Component | Feeling | Pain Point Addressed |
+|------|--------|-------------------|---------|---------------------|
+| 1 | Scout opens app after returning from trip (anytime) | Home / Event list | "Want to share while I remember" | Feedback no longer deferred to next meeting |
+| 2 | Selects completed event, opens feedback | Event Detail → Feedback tab | Easy — meals listed with recipes | Clear structure vs. vague "what did you think?" |
+| 3 | Rates a meal: star rating, portion assessment (too much / just right / too little) | Feedback form | Quick — structured taps, not essay writing | Low friction encourages participation |
+| 4 | Adds optional free-text comment | Feedback form (text area) | Expressive — can add detail if motivated | Captures specifics that structured ratings miss |
+| 5 | Submits feedback (content moderation runs) | Submit button → success confirmation | Accomplished — "my input counts" | Feedback persists with the recipe for future planners |
+| 6 | Next planning meeting: SPL views recipe with aggregated ratings and past comments | Recipe Detail → Feedback History | Informed — data-driven meal selection | Institutional knowledge preserved across trips |
+
+## 4. Scope
+### In Scope
+* Event creation with dates, times, headcount, and trip logistics (camping type, power, water, trailer, hiking, altitude, weather).
+* Meal scheduling — define meals per day (breakfast, lunch, dinner, snacks) with parameters (trailside, time-constrained, multi-course, headcount).
+* Meal selection recording — SPL records decided meals (no in-app brainstorming or voting).
+* Recipe and ingredient management — ingredients with quantities, instructions, cooking method, required equipment (pots, pans, utensils, spices/condiments).
+* Dynamic recipe scaling by headcount.
+* Equipment list generation — consolidated from assigned recipes.
+* Shopping list generation — consolidated with quantities and estimated prices, divided by meal, emailable.
+* Printable recipes for trip use.
+* Plan sharing — shareable read-only link (no login required).
+* Recipe library — save and reuse across events.
+* Post-trip feedback — structured ratings, portion assessment, free-text comments.
+* Dietary restrictions at meal level (never linked to individual people).
+* Content moderation for user-generated text.
+* Authentication via Microsoft Entra ID with role-based access.
+
+### Out of Scope (justify if empty)
+* Multi-troop-per-user support and cross-troop recipe sharing — post-MVP when pilot validates the model. Multi-troop will introduce a new admin role for approving new troops. Note: the current architecture is already multi-tenant (multiple troops coexist safely with data isolated by `troopId`); what is deferred is allowing a single user to belong to more than one troop with a troop-switcher UI.
+* Patrol management within the app — one scout records information; patrol structure is managed offline.
+* In-app brainstorming and voting — SPL records decisions made during in-person discussion.
+* Individual scout shopper assignment in-app — shopping lists are emailed instead.
+* Advanced filtering, favorites, and search — basic search only for MVP.
+* Advanced feedback analytics and dashboards — inline feedback history is sufficient.
+* Nutrition checker — validate daily meal plans against Scouting America nutritional guidelines (protein, fruits/vegetables, grains, etc.). Post-MVP; requires sourcing the specific guideline requirements.
+* Budget tracking and purchase receipt capture.
+* Offline-first / PWA capabilities.
+* Native mobile app (iPhone / Android).
+* Integration with external shopping or calendar services.
+
+### Assumptions
+* Scouts and leaders have access to a web browser on phone or computer.
+* The pilot troop has 3 patrols (typical structure).
+* Internet access is available during planning meetings (not required on the trip).
+* The Scoutmaster currently transcribes and forwards plans manually; the app replaces this step.
+
+### Constraints
+* Single developer building and maintaining the application.
+* Prototype by May 2026; production-ready by September 2026.
+* Youth safety: only first names for youth members; no email/phone/address for minors without guardian consent.
+* Dietary restrictions at meal level only — never linked to individuals (sensitive information).
+* Scouting America compliance review required before youth access.
+* Content moderation required for all user-generated text.
+* Mobile-first web — scouts primarily use phones; must be fully functional on mobile browsers.
+* Headcount range: 8–35+ people.
+
+## 5. Product Overview
+### Value Proposition
+A purpose-built meal planning tool for scout troops that preserves scout-led planning culture while providing structured digital record-keeping, automatic list generation, and seamless communication with parents — eliminating manual transcription, lost records, and forgotten equipment.
+
+### Differentiators (Optional)
+* Designed specifically for scout troop meal planning workflows (not a generic meal planner).
+* Preserves scout-led decision-making while providing digital structure.
+* Youth safety by design — minimal PII, content moderation, role-based access.
+* Printable recipes for offline trip use.
+* Shareable read-only links for parent visibility without requiring accounts.
+
+### UX / UI (Conditional)
+**Design direction**: Outdoor adventure combined with practical organization. Should feel like a well-organized field guide — purposeful, rugged, and reliable. Easy to use in various lighting conditions.
+
+**Color palette**:
+- Primary: Deep Forest Green (oklch(0.45 0.09 155))
+- Secondary: Warm Stone Gray (oklch(0.70 0.01 85)), Deep Earth Brown (oklch(0.35 0.04 60))
+- Accent: Campfire Orange (oklch(0.68 0.18 50))
+- All foreground/background pairings meet WCAG AA contrast ratios.
+
+**Typography**:
+- Headings: Space Grotesk (Bold/Semibold/Medium, 18–32px)
+- Body: Source Sans 3 (Regular/Medium, 13–16px)
+- Designed for outdoor readability with clear hierarchy.
+
+**Key interaction patterns**:
+- Spring-based list reordering animations.
+- Number animations on recipe scaling.
+- Satisfying check-off animations for shopping/equipment lists.
+- Fluid accordion-style recipe detail expansion.
+- Mobile: single column, bottom sheet navigation, sticky headers, 44x44px touch targets.
+
+**Component library**: shadcn/ui (Radix + Tailwind CSS) — Card, Accordion, Dialog, Tabs, Select, Input, Button, Checkbox, Badge, Separator, Scroll Area, Command.
+
+| UX Status | Notes |
+|-----------|-------|
+| Design direction | Defined — outdoor field guide aesthetic |
+| Color palette | Defined — forest green, stone gray, earth brown, campfire orange |
+| Typography | Defined — Space Grotesk headings, Source Sans 3 body |
+| Component library | Selected — shadcn/ui |
+| Mobile patterns | Defined — single column, bottom sheet nav, sticky headers |
+| Wireframes | TBD |
+| User journey maps | TBD |
+
+## 6. Functional Requirements
+
+### Event Management
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-001 | Create event | User creates an event with name, date range, departure time, return time, and expected headcount (scouts, adults, guests). | G-001 | SPL, Scoutmaster | Must | Event persisted with all fields. Date range, times, and headcount editable after creation. | BRD: BR-001 |
+| FR-002 | Trip logistics | User captures trip logistics: camping type (tent/cabin), power availability, running water, trailer access, hiking trip, cooking at altitude, expected weather. | G-002, G-003 | SPL, Scoutmaster | Must | Logistics fields visible when planning meals and selecting recipes. | BRD: BR-002 |
+| FR-003 | Meal scheduling | User defines meals for each day: breakfast, lunch, dinner, and snacks. | G-001 | SPL | Must | Each day shows meal slots. Meals can be added and removed. | BRD: BR-003 |
+| FR-004 | Meal parameters | User marks a meal as trailside or time-constrained. | G-002 | SPL | Should | Flags visible on meal and in schedule view. | BRD: BR-004 |
+| FR-005 | Multi-course meals | User indicates a meal has multiple courses (e.g., dinner with dessert). | G-002 | SPL | Should | Multiple recipes assignable to a single meal slot. | BRD: BR-005 |
+| FR-006 | Dietary restrictions | User records dietary restrictions or considerations at the meal level (e.g., nut allergy, vegetarian option needed). Never linked to individuals. | G-002 | SPL, Scoutmaster | Must | Dietary notes visible on meal in schedule view and when selecting recipes. No association with a specific person. | BRD: BR-027 |
+
+### Recipe Management
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-007 | Create recipe | User creates a recipe with name, ingredient list (item, quantity, unit), step-by-step instructions, and cooking method. | G-002, G-004 | SPL, Scout | Must | Recipe saved to library with all fields editable. | BRD: BR-006 |
+| FR-008 | Recipe equipment | User specifies required equipment: pots, pans, utensils, and supplemental items (spices, condiments). | G-003 | SPL, Scout | Must | Equipment stored with recipe and appears on event equipment list. | BRD: BR-007 |
+| FR-009 | Assign recipe to meal | User assigns a recipe from the library to a meal slot on an event. | G-001, G-002 | SPL | Must | Assigned recipe's ingredients and equipment flow into shopping and equipment lists. | BRD: BR-008 |
+| FR-010 | Recipe library | User saves a recipe to the troop library for reuse across events. | G-001 | SPL, Scout | Must | Saved recipes searchable and selectable when assigning to a meal. | BRD: BR-009 |
+| FR-011 | Recipe scaling | Recipes scale by headcount — ingredient quantities adjust proportionally. | G-002 | SPL | Must | Quantities recalculate when headcount changes. Fractions display as practical cooking measurements. | BRD: BR-010 |
+| FR-012 | Print recipe | User prints a recipe in a trip-ready format (ingredients, instructions, equipment on one page). | G-004 | Scout | Must | Browser print produces clean, readable single-recipe printout. | BRD: BR-011 |
+
+### Shopping List
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-013 | Generate shopping list | System generates a consolidated shopping list from all assigned recipes, scaled to headcount. | G-002 | SPL, Scout | Must | Duplicates combined with summed quantities. Updates when meals or headcount change. | BRD: BR-012 |
+| FR-014 | Estimated prices | Shopping list displays estimated price per item when provided. | G-002 | SPL | Should | Price column visible. Total estimated cost shown. | BRD: BR-013 |
+| FR-015 | Email shopping list | User emails the shopping list (or portion) to a specified email address. | G-005 | SPL, Scoutmaster | Must | Email sent with readable list. Recipient does not need an account. | BRD: BR-014 |
+| FR-016 | Check off purchases | Shopping list items can be checked off as purchased. | G-002 | Scout | Should | Checked state persists across sessions. | BRD: BR-015 |
+
+### Equipment List
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-017 | Generate equipment list | System generates a consolidated equipment list from all assigned recipes. | G-003 | SPL | Must | Duplicates consolidated. Updates when meal assignments change. | BRD: BR-016 |
+| FR-018 | Check off packed items | Equipment list items can be checked off as packed. | G-003 | Scout | Should | Checked state persists across sessions. | BRD: BR-017 |
+
+### Plan Sharing
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-019 | Shareable read-only link | User generates a shareable read-only link to the event plan (schedule, recipes, shopping list, equipment list). | G-005 | Scoutmaster | Must | Link accessible without login. Displays current plan state. | BRD: BR-018 |
+
+### Feedback
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-020 | Submit meal feedback | After a trip, scouts submit structured feedback: rating, portion assessment (too much / just right / too little), and free-text comments. | G-004 | Scout | Must | Feedback linked to specific meal and recipe. Multiple scouts can submit for same meal. | BRD: BR-019 |
+| FR-021 | Feedback on recipe detail | Feedback history visible on recipe in library — aggregated ratings and individual comments from past events. | G-001, G-004 | SPL | Must | Recipe detail shows past ratings and comments. | BRD: BR-020 |
+| FR-022 | Anytime feedback | Feedback submittable any time after event ends, not only at next meeting. | G-004 | Scout | Must | Feedback form available from event detail as soon as event end date passes. | BRD: BR-021 |
+
+### Safety, Compliance & Auth
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-023 | Content moderation | All user-generated text scanned by content moderation service before storage or display. | Compliance | All | Must | Offensive content flagged and not displayed. Flagged content reviewable by Scoutmaster. | BRD: BR-022 |
+| FR-024 | Youth PII minimization | Application stores only first names for youth. No email, phone, or address for minors without guardian consent. | Compliance | All | Must | Youth account creation does not require or store PII beyond first name and auth token. | BRD: BR-023 |
+| FR-025 | Admin content review | Scoutmaster has admin access to review flagged content and manage troop membership. | Compliance | Scoutmaster | Must | Admin view shows flagged items. Scoutmaster can approve, edit, or remove. | BRD: BR-024 |
+| FR-026 | Authentication | Users authenticate via Microsoft Entra ID (consumer accounts). | Compliance | All | Must | Login via MSAL. Session persists across browser refreshes. | BRD: BR-025 |
+| FR-027 | Role-based access | Scoutmaster (admin), Leader (edit), Scout (edit assigned, submit feedback), Parent (read-only via shared link). | Compliance | All | Must | Each role sees only permitted actions. Unauthorized actions rejected by API. | BRD: BR-026 |
+
+### Troop Administration
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-028 | Invite members | Scoutmaster invites new members by generating an invite code or sending an invite link through the UI when adding a member. | Compliance | Scoutmaster | Must | Invite code and invite link both produce a valid join flow. New member appears in troop roster after accepting. | BRD: BR-024 |
+| FR-029 | Assign and change roles | Scoutmaster assigns or changes a member's role (Leader, Scout). | Compliance | Scoutmaster | Must | Role change takes effect immediately. Member sees updated permissions on next action. | BRD: BR-024 |
+| FR-030 | Deactivate or remove members | Scoutmaster deactivates or removes a member from the troop. Deactivated members lose access but data is retained. Removed members are permanently dissociated. | Compliance | Scoutmaster | Must | Deactivated member cannot log in to troop. Removed member no longer appears in roster. Feedback and event history attributed to deactivated members remain intact. | BRD: BR-024 |
+
+### Feature Hierarchy (Optional)
+```plain
+Scout Meal Planner MVP
+├── Event Management
+│   ├── Create/Edit Event (FR-001, FR-002)
+│   ├── Meal Scheduling (FR-003, FR-004, FR-005)
+│   └── Dietary Restrictions (FR-006)
+├── Recipe Management
+│   ├── Create/Edit Recipe (FR-007, FR-008)
+│   ├── Recipe Library (FR-010)
+│   ├── Assign to Meal (FR-009)
+│   ├── Recipe Scaling (FR-011)
+│   └── Print Recipe (FR-012)
+├── Lists
+│   ├── Shopping List (FR-013, FR-014, FR-015, FR-016)
+│   └── Equipment List (FR-017, FR-018)
+├── Communication
+│   ├── Shareable Link (FR-019)
+│   └── Email Shopping List (FR-015)
+├── Feedback
+│   ├── Submit Feedback (FR-020, FR-022)
+│   └── Feedback History (FR-021)
+├── Troop Administration
+│   ├── Invite Members (FR-028)
+│   ├── Assign Roles (FR-029)
+│   └── Deactivate/Remove Members (FR-030)
+└── Safety & Auth
+    ├── Authentication (FR-026)
+    ├── Role-Based Access (FR-027)
+    ├── Content Moderation (FR-023)
+    ├── Youth PII (FR-024)
+    └── Admin Review (FR-025)
+```
+
+## 7. Non-Functional Requirements
+| NFR ID | Category | Requirement | Metric/Target | Priority | Validation | Notes |
+|--------|----------|------------|--------------|----------|-----------|-------|
+| NFR-001 | Performance | Page load time on mobile | Responsive during meetings — no specific ms target; optimize for perceived speed on mobile | Must | Manual testing during pilot meetings; Lighthouse as guidance | MVP: optimize for feel, not a hard number |
+| NFR-002 | Performance | API response time | Fast enough not to frustrate scouts — no hard latency target | Must | Manual testing; AppInsights latency monitoring | Revisit with real usage data post-launch |
+| NFR-003 | Reliability | Application uptime | Azure SWA default (~99.95% SLA) | Must | Azure platform SLA + AppInsights availability | No custom SLA for pilot |
+| NFR-004 | Scalability | Concurrent users supported | Pilot: single troop, 20–35 users | Should | Organic pilot usage | Revisit if multi-troop added |
+| NFR-005 | Security | Authentication via Entra ID | All API calls require valid JWT | Must | Auth middleware tests | Implemented |
+| NFR-006 | Security | Content moderation latency | Non-blocking UX — moderation can run async if needed | Must | Integration testing with sandbox | |
+| NFR-007 | Privacy | Youth PII minimization | Only first name + auth token stored for minors | Must | Data audit | |
+| NFR-008 | Accessibility | WCAG 2.1 AA compliance | All color pairings meet contrast ratios | Should | axe-core audit | Color palette verified |
+| NFR-009 | Maintainability | TypeScript strict mode | Zero `any` types in production code | Must | Build-time check | Active |
+| NFR-010 | Maintainability | Test coverage | ~70% unit coverage for API, key component tests for frontend, one smoke e2e suite | Should | Vitest coverage report + Playwright smoke suite | Realistic for solo developer |
+| NFR-011 | Mobile | Mobile-first responsive design | Fully functional on mobile browsers, 44x44px touch targets | Must | Manual testing on devices | |
+| NFR-012 | Localization | English only for MVP | N/A | — | — | Post-MVP consideration |
+
+## 8. Data & Analytics (Conditional)
+### Inputs
+* Event data: name, dates, times, headcount, logistics, meal schedule, recipe assignments.
+* Recipe data: name, ingredients (item/quantity/unit), instructions, cooking method, equipment.
+* Feedback data: ratings, portion assessments, free-text comments per meal per scout.
+* User data: first name, auth token, role assignment.
+
+### Outputs / Events
+* Shopping lists: consolidated, scaled, emailable.
+* Equipment lists: consolidated from assigned recipes.
+* Shareable read-only event plan links.
+* Printable recipe pages.
+* Aggregated feedback on recipe detail pages.
+
+### Instrumentation Plan
+| Event | Trigger | Payload | Purpose | Owner |
+|-------|---------|--------|---------|-------|
+| Event created | User creates event | eventId, troopId, headcount | Track planning activity | Dev |
+| Recipe assigned | Recipe assigned to meal | eventId, recipeId, mealSlot | Track recipe reuse | Dev |
+| Shopping list emailed | User emails shopping list | eventId, recipientCount | Track communication feature usage | Dev |
+| Feedback submitted | Scout submits feedback | eventId, recipeId, rating | Track feedback engagement | Dev |
+| Content flagged | Moderation flags content | contentType, severity | Track moderation activity | Dev |
+| Shared link generated | User creates shareable link | eventId | Track sharing adoption | Dev |
+
+### Metrics & Success Criteria
+| Metric | Type | Baseline | Target | Window | Source |
+|--------|------|----------|--------|--------|--------|
+| Meeting time on meal planning | Operational | 30–60+ min | ≤15 min | By 3rd trip | Scoutmaster observation |
+| Shopping list accuracy | Operational | Errors most trips | Zero errors | By 3rd trip | Post-trip retrospective |
+| Equipment list completeness | Operational | Items forgotten most trips | Zero omissions | By 3rd trip | Post-trip retrospective |
+| Recipe availability on trip | Operational | Often incomplete | 100% accessible | By 2nd trip | Spot-check at departure |
+| User adoption rate (pilot) | Adoption | 0% | 80% active scouts | Per planning cycle | Unique logins |
+| Feedback submission rate | Engagement | Informal only | ≥50% attendees | Per trip | In-app count vs. roster |
+
+## 9. Dependencies
+| Dependency | Type | Criticality | Owner | Risk | Mitigation |
+|-----------|------|------------|-------|------|-----------|
+| Scouting America compliance review | Regulatory | High | Scoutmaster / Council | Blocks youth access | Research early; adults-only workaround possible |
+| Azure Content Safety integration | Service | High | Developer | Blocks UGC features | Manual review fallback during pilot |
+| Microsoft Entra ID (MSAL) | Service | High | Developer | Blocks multi-user access | In progress; consumer accounts |
+
+## 10. Risks & Mitigations
+| Risk ID | Description | Severity | Likelihood | Mitigation | Owner | Status |
+|---------|-------------|---------|-----------|-----------|-------|--------|
+| RSK-001 | Scouting America compliance blocks youth access | High | High | Research policies early, design for compliance, engage council contacts | Scoutmaster + Dev | Not started |
+| RSK-002 | Content moderation fails to catch inappropriate content | High | Medium | Integrate Azure Content Safety, manual review during pilot, reporting mechanism | Dev | Not started |
+| RSK-003 | Low scout adoption — revert to informal methods | High | Medium | Involve SPL in design feedback, fast mobile UX, demonstrate value on first trip | Dev + Scoutmaster | Not started |
+| RSK-004 | Single developer bottleneck delays September launch | Medium | Medium | Ruthless MVP prioritization, use shadcn/ui, accept rough edges in non-critical areas | Dev | Active |
+| RSK-005 | Poor mobile experience | Medium | Medium | Mobile-first design, test on actual scout devices during prototype | Dev | Active |
+| RSK-006 | Feedback not captured — scouts forget or skip it | Medium | Low | Enable feedback immediately after trip, in-app reminders | Dev | Not started |
+| RSK-007 | PII exposure for minor scouts | High | Low | First names only, no email/phone for minors, access controls, data retention policies | Dev | Partially addressed |
+
+## 11. Privacy, Security & Compliance
+### Data Classification
+* **Public**: Shared read-only event plans (via shareable link).
+* **Internal**: Recipes, meal schedules, shopping lists, equipment lists, event details.
+* **Sensitive**: Dietary restrictions (meal-level only, never person-linked), feedback comments, flagged content.
+* **Restricted**: Authentication tokens, user role assignments.
+
+### PII Handling
+* Youth members: first name + auth token only. No email, phone, or address without guardian consent.
+* Adult members: name + Microsoft account (via Entra ID). No additional PII stored by the application.
+* Parents: no account required — access via shareable read-only link.
+
+### Threat Considerations
+* Unauthorized access to troop data — mitigated by Entra ID auth + RBAC middleware.
+* Inappropriate content from youth users — mitigated by content moderation service.
+* PII leakage for minors — mitigated by minimal data collection and meal-level dietary restrictions.
+* Shareable link exposure — links are read-only, contain no PII, can be regenerated/revoked.
+
+### Regulatory / Compliance (Conditional)
+| Regulation | Applicability | Action | Owner | Status |
+|-----------|--------------|--------|-------|--------|
+| Scouting America technology platform policy | Required for youth-facing app | Compliance review before youth access | Scoutmaster / Council | Not started |
+| COPPA (Children's Online Privacy Protection Act) | Potentially applicable if users under 13 | Minimize PII, parental consent for minors, review data practices | Dev | Design addresses; legal review TBD |
+
+## 12. Operational Considerations
+| Aspect | Requirement | Notes |
+|--------|------------|-------|
+| Deployment | GitHub Actions CI/CD: CI on PRs (build + test), deploy on push to `main`. Frontend → Azure SWA via `static-web-apps-deploy`. API → Azure Functions via blob deploy + restart. Infra → Bicep via manual workflow dispatch. | 3 workflows: `ci.yml`, `deploy.yml`, `infra.yml`. Smart path filtering skips unchanged components. |
+| Rollback | Redeploy previous version from `main` branch | Sufficient for MVP; no blue/green or slot-based deployment needed |
+| Monitoring | Azure Application Insights | Instrument frontend and API for request tracing, latency, errors, and availability |
+| Alerting | AppInsights default alerts (failures, availability) | Fine-tune alert thresholds after pilot usage establishes baselines |
+| Support | Single developer + Scoutmaster for pilot | No formal support model for MVP |
+| Capacity Planning | Pilot: single troop (20–35 users), low RU consumption | Monitor Cosmos DB RUs via AppInsights |
+
+## 13. Rollout & Launch Plan
+### Phases / Milestones
+| Phase | Date | Gate Criteria | Owner |
+|-------|------|--------------|-------|
+| Prototype | May 2026 | Core event + recipe + list flows demo-ready; AppInsights instrumented | Dev |
+| Scouting America compliance review | May–Jun 2026 | Policy review complete, any required changes implemented | Scoutmaster + Dev |
+| Content moderation integration | Jun–Jul 2026 | Azure Content Safety active, flagging tested via sandbox | Dev |
+| Beta (adults only) | Jul–Aug 2026 | Scoutmaster + leaders can create events and plan meals end-to-end | Dev |
+| MVP Launch | September 2026 | All Must requirements pass acceptance, compliance cleared, CI green | Dev + Scoutmaster |
+
+### Feature Flags (Conditional)
+
+Feature flags enable progressive rollout, safe experimentation, and quick kill-switches without redeployment. Flags are evaluated at runtime and can be toggled per environment (dev, beta, production).
+
+**Implementation approach**: Use a simple flags configuration (e.g., environment variables or a JSON config served by the API) for MVP. Migrate to Azure App Configuration feature management if flag count or complexity grows post-MVP.
+
+**Flag lifecycle**: Each flag has a sunset criteria — once the feature is stable and fully rolled out, remove the flag and the conditional code. Stale flags add complexity.
+
+| Flag | Purpose | Default | Sunset Criteria |
+|------|---------|--------|----------------|
+| `enable-content-moderation` | Gate Azure Content Safety integration. Off during early dev; on for beta and launch. Allows fallback to manual-only review if service has issues. | Off (dev), On (beta+) | Remove after 2 successful trips with moderation active and no service issues |
+| `enable-email-shopping-list` | Gate email sending for shopping lists (FR-015). Prevents accidental emails during development and testing. | Off (dev), On (beta+) | Remove after email integration confirmed working in production |
+| `enable-shared-links` | Gate shareable read-only link generation (FR-019). Allows testing the view without exposing real links prematurely. | Off (dev), On (beta+) | Remove after first shared link successfully used by a parent |
+| `enable-feedback` | Gate post-trip feedback submission (FR-020–022). Can be turned off if content moderation is not yet active (feedback includes free text). | Off (until content moderation active) | Remove after 2 trips with feedback successfully collected |
+| `enable-print-recipes` | Gate print-formatted recipe view (FR-012). Low risk, but useful to defer print CSS work until core flows are solid. | On | Remove after print format validated on actual trip |
+
+**Principles for effective flag usage**:
+1. **One flag per independently deployable capability** — don’t bundle unrelated features behind a single flag.
+2. **Default to off for anything with external side effects** (emails, shared links, third-party API calls).
+3. **Default to on for pure UI features** that don’t affect data or external systems.
+4. **Always test both paths** — write at least one test with the flag on and one with it off.
+5. **Sunset aggressively** — once a feature is stable in production, remove the flag within the next release cycle. Dead flags are technical debt.
+6. **Log flag evaluations** — emit an AppInsights event when a flag changes user experience, so you can correlate behavior with flag state.
+
+### Communication Plan (Optional)
+1. **Scoutmaster** introduces tool at a troop meeting (beta phase).
+2. **SPL walkthrough** — developer demos core planning flow with SPL before first real use.
+3. **Parent notification** — Scoutmaster shares info via existing troop communication channel (email list / Remind app) when shared links go live.
+4. **Feedback loop** — collect informal usability feedback from SPL and Scoutmaster after first 2 trips.
+
+## 14. Open Questions
+| Q ID | Question | Owner | Deadline | Status |
+|------|----------|-------|---------|--------|
+| OQ-001 | What are Scouting America's specific technology platform requirements for youth-facing apps? | Scoutmaster | Before prototype | Open |
+| OQ-002 | ~~What performance targets are appropriate for mobile page load and API response times?~~ | Dev | — | Resolved — optimize for perceived speed, no hard targets |
+| OQ-003 | ~~What test coverage target is realistic for a solo developer?~~ | Dev | — | Resolved — ~70% API unit, key frontend components, smoke e2e |
+| OQ-004 | Should the app support COPPA compliance explicitly, or is Scouting America compliance sufficient? | Dev | Before youth access | Open |
+| OQ-005 | ~~What is the monitoring and alerting strategy for the MVP?~~ | Dev | — | Resolved — Azure Application Insights with default alerts |
+
+## 15. Changelog
+| Version | Date | Author | Summary | Type |
+|---------|------|-------|---------|------|
+| 0.1 | 2026-04-18 | andyrob | Initial PRD draft — populated from approved BRD v1.0 and existing design direction | Creation |
+| 1.0 | 2026-04-18 | andyrob | Approved — added troop admin FRs (FR-028–030), feature flags, user journeys, communication plan. 2 open questions remain (external dependencies, not blockers). | Approval |
+
+## 16. References & Provenance
+| Ref ID | Type | Source | Summary | Conflict Resolution |
+|--------|------|--------|---------|--------------------|
+| REF-001 | BRD | docs/brds/scout-meal-planner-mvp-brd.md | Approved BRD v1.0 — 27 business requirements, objectives, process flows, risks | Primary source for all functional requirements |
+| REF-002 | Design | PRD.md (root) | Original PRD with design direction — colors, fonts, components, animations, mobile patterns | Design elements preserved; feature scope replaced by BRD |
+
+### Citation Usage
+All functional requirements (FR-001 through FR-027) trace directly to BRD business requirements (BR-001 through BR-027). Design direction (Section 5 UX/UI) preserved from REF-002. Feature scope and priorities governed by REF-001.
+
+## 17. Appendices (Optional)
+### Glossary
+| Term | Definition |
+|------|-----------|
+| Troop | A local unit of scouts led by adult volunteers |
+| Scoutmaster | The primary adult leader responsible for a troop |
+| SPL (Senior Patrol Leader) | The elected youth leader of the troop who facilitates meetings and planning |
+| Patrol | A small group of scouts within a troop (typically 6–8 scouts) |
+| Event | A camping trip or multi-day activity requiring meal planning |
+| Trailside meal | A meal prepared in advance because on-site cooking is not feasible |
+| Headcount | Total people to feed: scouts + adults + guests |
+
+### Additional Notes
+**Technology stack**: React + Vite frontend, Azure Functions v4 (Node.js) API, Azure Cosmos DB, Azure Static Web App, Microsoft Entra ID (MSAL), Tailwind CSS, shadcn/ui, TanStack Query, Zod schemas, Vitest + Playwright.
+
+Generated 2026-04-18 by PRD Builder (mode: iterative)
+<!-- markdown-table-prettify-ignore-end -->

--- a/docs/prds/scout-meal-planner-mvp.md
+++ b/docs/prds/scout-meal-planner-mvp.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable-file -->
 <!-- markdown-table-prettify-ignore-start -->
 # Scout Meal Planner MVP — Product Requirements Document (PRD)
-Version 1.0 | Status Approved | Owner andyrob | Team Solo Developer | Target September 2026 | Lifecycle MVP
+Version 1.2 | Status Approved | Owner andyrob | Team Solo Developer | Target September 2026 | Lifecycle MVP
 
 ## Progress Tracker
 | Phase | Done | Gaps | Updated |
@@ -13,7 +13,7 @@ Version 1.0 | Status Approved | Owner andyrob | Team Solo Developer | Target Sep
 | Metrics & Risks | Yes | None | 2026-04-18 |
 | Operationalization | Yes | None | 2026-04-18 |
 | Finalization | Yes | None | 2026-04-18 |
-Unresolved Critical Questions: 2 | TBDs: 0
+Unresolved Critical Questions: 0 | TBDs: 0
 
 ## 1. Executive Summary
 ### Context
@@ -382,7 +382,11 @@ See [Privacy Policy](../policies/privacy-policy.md) for the full data handling r
 ### Regulatory / Compliance (Conditional)
 | Regulation | Applicability | Action | Owner | Status |
 |-----------|--------------|--------|-------|--------|
-| Scouting America technology platform policy | Required for youth-facing app | Compliance review before youth access | Scoutmaster / Council | Not started |
+| Scouting America Youth Protection Policy | Required — applies to all online and technology-mediated interactions with youth | No one-on-one adult–youth digital comms (app has no messaging); group/moderated model; role-based access separates youth and adult capabilities (FR-026, FR-027) | Scoutmaster / Council | Addressed by design |
+| Scouting America Digital Safety & Online Conduct | Required — governs how technology may be used with youth | Content moderation (FR-023), admin content review (FR-025), no private DM feature, community standards enforced by RBAC | Dev | Addressed by design |
+| Scouting America Cyber Chip alignment | Required — youth digital safety pledges must not be contradicted | Platform does not enable unsupervised meetings, private contact, or risky sharing; read-only shareable links contain no PII | Dev | Addressed by design |
+| Scouting America age-appropriate access | Required — digital participation must be age-segmented, supervised, guardian-approved | RBAC roles separate scout/adult capabilities; COPPA consent model (Section 11); Microsoft Family accounts for under-13 | Dev | Addressed by design |
+| Scouting America approved platform policy | Required — council/unit must approve youth-facing tools | Scoutmaster approval gate before youth access (Phase 2 rollout); council notification if required | Scoutmaster / Council | Pending — approval before youth access |
 | COPPA (Children's Online Privacy Protection Act) | Potentially applicable if users under 13 | Minimize PII, parental consent for minors, review data practices | Dev | Design addresses; legal review TBD |
 
 ## 12. Operational Considerations
@@ -438,7 +442,7 @@ Feature flags enable progressive rollout, safe experimentation, and quick kill-s
 ## 14. Open Questions
 | Q ID | Question | Owner | Deadline | Status |
 |------|----------|-------|---------|--------|
-| OQ-001 | What are Scouting America's specific technology platform requirements for youth-facing apps? | Scoutmaster | Before prototype | Open |
+| OQ-001 | ~~What are Scouting America's specific technology platform requirements for youth-facing apps?~~ | Scoutmaster | — | Resolved — Scouting America does not publish a prescriptive technical checklist. Requirements are defined through five mandatory policy areas: (1) Youth Protection — no one-on-one digital communication, auditable channels; (2) Digital Safety — moderation, reporting, no unsupervised private interaction; (3) Cyber Chip alignment — platform must not enable behavior conflicting with youth digital safety pledges; (4) Age-appropriate access — age-segmented, supervised, guardian-approved; (5) Approved platforms — council/unit approval required. The PRD addresses all five: no messaging feature (1), content moderation FR-023/FR-025 (2), no conflicting features (3), RBAC + COPPA consent model (4), Scoutmaster approval gate in rollout (5). See REF-003–REF-006. |
 | OQ-002 | ~~What performance targets are appropriate for mobile page load and API response times?~~ | Dev | — | Resolved — optimize for perceived speed, no hard targets |
 | OQ-003 | ~~What test coverage target is realistic for a solo developer?~~ | Dev | — | Resolved — ~70% API unit, key frontend components, smoke e2e |
 | OQ-004 | ~~Should the app support COPPA compliance explicitly, or is Scouting America compliance sufficient?~~ | Dev | — | Resolved — MVP uses Microsoft Family accounts for parental consent, consent notice at join, admin-assisted data deletion (FR-031), and a privacy policy. Dedicated parent role deferred to post-MVP. |
@@ -450,15 +454,20 @@ Feature flags enable progressive rollout, safe experimentation, and quick kill-s
 | 0.1 | 2026-04-18 | andyrob | Initial PRD draft — populated from approved BRD v1.0 and existing design direction | Creation |
 | 1.0 | 2026-04-18 | andyrob | Approved — added troop admin FRs (FR-028–030), feature flags, user journeys, communication plan. 2 open questions remain (external dependencies, not blockers). | Approval |
 | 1.1 | 2026-04-18 | andyrob | Added COPPA consent model (Section 11), FR-031 (member data deletion), resolved OQ-004, added parent role to out-of-scope, linked privacy policy. | Update |
+| 1.2 | 2026-04-18 | andyrob | Resolved OQ-001 with Scouting America policy research. Expanded compliance table from 1 row to 5 policy areas. Added REF-003–REF-006 (Scouting America policy sources). All open questions now resolved. | Update |
 
 ## 16. References & Provenance
 | Ref ID | Type | Source | Summary | Conflict Resolution |
 |--------|------|--------|---------|--------------------|
 | REF-001 | BRD | docs/brds/scout-meal-planner-mvp-brd.md | Approved BRD v1.0 — 27 business requirements, objectives, process flows, risks | Primary source for all functional requirements |
 | REF-002 | Design | PRD.md (root) | Original PRD with design direction — colors, fonts, components, animations, mobile patterns | Design elements preserved; feature scope replaced by BRD |
+| REF-003 | Policy | [Scouting America Youth Protection](https://www.scouting.org/training/youth-protection/) | Youth Protection policy — applies to online and technology-mediated interactions; no one-on-one adult–youth digital communication; transparency and auditable channels required | Scouting America policy is authoritative for youth safety requirements |
+| REF-004 | Policy | [Digital Safety and Online Scouting Activities](https://www.scouting.org/health-and-safety/safety-moments/digital-safety-and-online-scouting-activities/) | Digital safety guidance — protection from inappropriate contact/content, safe online behavior per Scout Oath and Law, no unsupervised private interaction | — |
+| REF-005 | Policy | [Scouting America official site](https://www.scouting.org/) | Age-segmented program design — digital participation follows same age-appropriate, supervised, guardian-approved principles as in-person activities | — |
+| REF-006 | Platform | [Scoutbook](https://www.scouting.org/resources/scoutbook/) | Official Scouting America digital platform — third-party apps must align with national youth protection policies; council/unit approval expected | — |
 
 ### Citation Usage
-All functional requirements (FR-001 through FR-027) trace directly to BRD business requirements (BR-001 through BR-027). Design direction (Section 5 UX/UI) preserved from REF-002. Feature scope and priorities governed by REF-001.
+All functional requirements (FR-001 through FR-027) trace directly to BRD business requirements (BR-001 through BR-027). Design direction (Section 5 UX/UI) preserved from REF-002. Feature scope and priorities governed by REF-001. Scouting America compliance requirements (Section 11 regulatory table) grounded in REF-003–REF-006.
 
 ## 17. Appendices (Optional)
 ### Glossary

--- a/docs/prds/scout-meal-planner-mvp.md
+++ b/docs/prds/scout-meal-planner-mvp.md
@@ -1,0 +1,465 @@
+<!-- markdownlint-disable-file -->
+<!-- markdown-table-prettify-ignore-start -->
+# Scout Meal Planner MVP — Product Requirements Document (PRD)
+Version 1.0 | Status Approved | Owner andyrob | Team Solo Developer | Target September 2026 | Lifecycle MVP
+
+## Progress Tracker
+| Phase | Done | Gaps | Updated |
+|-------|------|------|---------|
+| Context | Yes | None | 2026-04-18 |
+| Problem & Users | Yes | None | 2026-04-18 |
+| Scope | Yes | None | 2026-04-18 |
+| Requirements | Yes | None | 2026-04-18 |
+| Metrics & Risks | Yes | None | 2026-04-18 |
+| Operationalization | Yes | None | 2026-04-18 |
+| Finalization | Yes | None | 2026-04-18 |
+Unresolved Critical Questions: 2 | TBDs: 0
+
+## 1. Executive Summary
+### Context
+Scout troops plan meals for camping trips as part of regular troop meetings. Today this process relies on informal methods — verbal discussion, paper notes, and ad-hoc text messages — leading to lost information, duplicated effort, and preventable mistakes on trips. This initiative delivers a web-based meal planning application piloted with a single scout troop.
+
+### Core Opportunity
+Replace informal, error-prone meal planning with a structured digital tool that preserves scout-led planning culture while eliminating manual transcription, lost records, and communication breakdowns between scouts, leaders, and parents.
+
+### Goals
+| Goal ID | Statement | Type | Baseline | Target | Timeframe | Priority |
+|---------|-----------|------|----------|--------|-----------|----------|
+| G-001 | Reduce meeting time spent on meal planning | Efficiency | 30–60+ min per meeting | ≤15 min per meeting | By 3rd trip using the app | Must |
+| G-002 | Eliminate incorrect food purchases on trips | Accuracy | Errors on most trips | Zero errors on routine trips | By 3rd trip using the app | Must |
+| G-003 | Ensure correct equipment is packed for each trip | Accuracy | Items forgotten most trips | Zero forgotten equipment | By 3rd trip using the app | Must |
+| G-004 | Ensure complete, accessible recipes on every trip | Completeness | Often incomplete or missing | 100% accessible at departure | By 2nd trip using the app | Must |
+| G-005 | Improve communication between scouts, leaders, and parents | Communication | Manual transcription every trip | Shareable link replaces transcription | Launch | Must |
+
+### Objectives (Optional)
+| Objective | Key Result | Priority | Owner |
+|-----------|------------|----------|-------|
+| Working prototype for early feedback | Demo-ready by May 2026 | Must | andyrob |
+| Production-ready for fall camping season | Live by September 2026 | Must | andyrob |
+| Pilot troop adoption | 80% of active scouts logging in per planning cycle | Must | andyrob + Scoutmaster |
+
+## 2. Problem Definition
+### Current Situation
+Meal planning occurs during troop meetings, led by the Senior Patrol Leader (SPL) with Scoutmaster oversight. The process involves verbal logistics briefing, brainstorming meal ideas, splitting into patrols to plan details, handoff to Scoutmaster for manual transcription, shopping, and post-trip retrospective. Recording is inconsistent (paper, phones, memory). The Scoutmaster transcription step is manual and error-prone. Feedback happens at the next meeting when details are forgotten. No reusable recipe records exist.
+
+### Problem Statement
+Meal planning for scout trips consumes excessive meeting time, produces inconsistent records, and creates communication breakdowns between scouts and adult leadership. These problems result in incorrect food purchases, forgotten or wrong equipment, and reduced time available for other troop activities.
+
+### Root Causes
+* Recording methods are inconsistent — some patrols use paper, some use phones, some rely on memory.
+* No single source of truth — plans are scattered across notes, texts, and verbal agreements.
+* Manual transcription by Scoutmaster is error-prone and time-consuming.
+* No persistent recipe library — the same planning effort repeats for similar meals.
+* Feedback is deferred to the next meeting, when attendees may be absent and details forgotten.
+* Equipment lists are incomplete or lost between planning and packing.
+
+### Impact of Inaction
+Continued meeting time waste (30–60+ min per trip), repeated shopping errors, forgotten equipment on trips, lost institutional cooking knowledge as scouts age out, and ongoing Scoutmaster burden from manual transcription.
+
+## 3. Users & Personas
+| Persona | Goals | Pain Points | Impact |
+|---------|-------|------------|--------|
+| Senior Patrol Leader (SPL) | Efficiently lead meal planning, record decisions, coordinate patrols | Spends too long on planning, records get lost, has to repeat work | High — primary user for planning workflow |
+| Scoutmaster | Reduce meeting overhead, ensure trip readiness, communicate plans to parents | Manual transcription, chasing down incomplete plans, no visibility until handoff | High — admin/oversight role |
+| Scout (general) | Plan meals, shop for ingredients, cook on trip, give feedback | Inconsistent records, forgotten equipment, feedback not captured | High — hands-on user |
+| Assistant Scoutmaster | Support planning, oversee scout participation | Duplicated oversight effort, no shared view of plan status | High — supporting role |
+| Parent | Visibility into meal plans, support purchasing and logistics | No access to plans without Scoutmaster forwarding | Medium — read-only consumer via shared link |
+
+### Journeys
+
+#### Journey 1: SPL Plans a Camping Trip (Primary Planning Flow)
+
+| Step | Action | Screen / Component | Feeling | Pain Point Addressed |
+|------|--------|-------------------|---------|---------------------|
+| 1 | SPL opens app on phone during troop meeting | Home / Event list | "Let’s get this done quickly" | Meetings run long on meal planning |
+| 2 | Creates new event: name, dates, headcount, logistics | Create Event dialog | Focused — quick structured form | Replaces verbal briefing and scattered notes |
+| 3 | Defines meal slots for each day (B/L/D/snacks), marks trailside or time-constrained | Event Schedule view | Organized — sees the whole trip at a glance | No more forgotten meal slots |
+| 4 | Adds dietary notes to meals as discussed | Meal detail | Confident — restrictions recorded without naming individuals | Sensitive info stays at meal level |
+| 5 | Browses recipe library, assigns recipes to meals (or creates new ones) | Recipe Library + Assign dialog | Efficient — reuses past recipes | Eliminates re-planning the same meals from scratch |
+| 6 | Reviews auto-generated shopping list and equipment list | Shopping List / Equipment List tabs | Relieved — consolidated and scaled automatically | No more manual tallying and missed items |
+| 7 | Emails shopping list to assigned scout shoppers | Email dialog | Done — shopping delegated in one tap | Replaces verbal assignments that get forgotten |
+| 8 | Scoutmaster reviews and shares read-only link with parents | Shareable Link action | Satisfied — no more manual transcription | Eliminates the Scoutmaster bottleneck |
+| 9 | Scouts print recipes before departure | Print Recipe action | Prepared — recipes in hand for the trip | No more missing or incomplete instructions on-site |
+
+#### Journey 2: Scout Submits Post-Trip Feedback
+
+| Step | Action | Screen / Component | Feeling | Pain Point Addressed |
+|------|--------|-------------------|---------|---------------------|
+| 1 | Scout opens app after returning from trip (anytime) | Home / Event list | "Want to share while I remember" | Feedback no longer deferred to next meeting |
+| 2 | Selects completed event, opens feedback | Event Detail → Feedback tab | Easy — meals listed with recipes | Clear structure vs. vague "what did you think?" |
+| 3 | Rates a meal: star rating, portion assessment (too much / just right / too little) | Feedback form | Quick — structured taps, not essay writing | Low friction encourages participation |
+| 4 | Adds optional free-text comment | Feedback form (text area) | Expressive — can add detail if motivated | Captures specifics that structured ratings miss |
+| 5 | Submits feedback (content moderation runs) | Submit button → success confirmation | Accomplished — "my input counts" | Feedback persists with the recipe for future planners |
+| 6 | Next planning meeting: SPL views recipe with aggregated ratings and past comments | Recipe Detail → Feedback History | Informed — data-driven meal selection | Institutional knowledge preserved across trips |
+
+## 4. Scope
+### In Scope
+* Event creation with dates, times, headcount, and trip logistics (camping type, power, water, trailer, hiking, altitude, weather).
+* Meal scheduling — define meals per day (breakfast, lunch, dinner, snacks) with parameters (trailside, time-constrained, multi-course, headcount).
+* Meal selection recording — SPL records decided meals (no in-app brainstorming or voting).
+* Recipe and ingredient management — ingredients with quantities, instructions, cooking method, required equipment (pots, pans, utensils, spices/condiments).
+* Dynamic recipe scaling by headcount.
+* Equipment list generation — consolidated from assigned recipes.
+* Shopping list generation — consolidated with quantities and estimated prices, divided by meal, emailable.
+* Printable recipes for trip use.
+* Plan sharing — shareable read-only link (no login required).
+* Recipe library — save and reuse across events.
+* Post-trip feedback — structured ratings, portion assessment, free-text comments.
+* Dietary restrictions at meal level (never linked to individual people).
+* Content moderation for user-generated text.
+* Authentication via Microsoft Entra ID with role-based access.
+
+### Out of Scope (justify if empty)
+* Multi-troop support and cross-troop recipe sharing — post-MVP when pilot validates the model. Multi-troop will introduce a new admin role for approving new troops.
+* Patrol management within the app — one scout records information; patrol structure is managed offline.
+* In-app brainstorming and voting — SPL records decisions made during in-person discussion.
+* Individual scout shopper assignment in-app — shopping lists are emailed instead.
+* Advanced filtering, favorites, and search — basic search only for MVP.
+* Advanced feedback analytics and dashboards — inline feedback history is sufficient.
+* Nutrition checker — validate daily meal plans against Scouting America nutritional guidelines (protein, fruits/vegetables, grains, etc.). Post-MVP; requires sourcing the specific guideline requirements.
+* Budget tracking and purchase receipt capture.
+* Offline-first / PWA capabilities.
+* Native mobile app (iPhone / Android).
+* Integration with external shopping or calendar services.
+
+### Assumptions
+* Scouts and leaders have access to a web browser on phone or computer.
+* The pilot troop has 3 patrols (typical structure).
+* Internet access is available during planning meetings (not required on the trip).
+* The Scoutmaster currently transcribes and forwards plans manually; the app replaces this step.
+
+### Constraints
+* Single developer building and maintaining the application.
+* Prototype by May 2026; production-ready by September 2026.
+* Youth safety: only first names for youth members; no email/phone/address for minors without guardian consent.
+* Dietary restrictions at meal level only — never linked to individuals (sensitive information).
+* Scouting America compliance review required before youth access.
+* Content moderation required for all user-generated text.
+* Mobile-first web — scouts primarily use phones; must be fully functional on mobile browsers.
+* Headcount range: 8–35+ people.
+
+## 5. Product Overview
+### Value Proposition
+A purpose-built meal planning tool for scout troops that preserves scout-led planning culture while providing structured digital record-keeping, automatic list generation, and seamless communication with parents — eliminating manual transcription, lost records, and forgotten equipment.
+
+### Differentiators (Optional)
+* Designed specifically for scout troop meal planning workflows (not a generic meal planner).
+* Preserves scout-led decision-making while providing digital structure.
+* Youth safety by design — minimal PII, content moderation, role-based access.
+* Printable recipes for offline trip use.
+* Shareable read-only links for parent visibility without requiring accounts.
+
+### UX / UI (Conditional)
+**Design direction**: Outdoor adventure combined with practical organization. Should feel like a well-organized field guide — purposeful, rugged, and reliable. Easy to use in various lighting conditions.
+
+**Color palette**:
+- Primary: Deep Forest Green (oklch(0.45 0.09 155))
+- Secondary: Warm Stone Gray (oklch(0.70 0.01 85)), Deep Earth Brown (oklch(0.35 0.04 60))
+- Accent: Campfire Orange (oklch(0.68 0.18 50))
+- All foreground/background pairings meet WCAG AA contrast ratios.
+
+**Typography**:
+- Headings: Space Grotesk (Bold/Semibold/Medium, 18–32px)
+- Body: Source Sans 3 (Regular/Medium, 13–16px)
+- Designed for outdoor readability with clear hierarchy.
+
+**Key interaction patterns**:
+- Spring-based list reordering animations.
+- Number animations on recipe scaling.
+- Satisfying check-off animations for shopping/equipment lists.
+- Fluid accordion-style recipe detail expansion.
+- Mobile: single column, bottom sheet navigation, sticky headers, 44x44px touch targets.
+
+**Component library**: shadcn/ui (Radix + Tailwind CSS) — Card, Accordion, Dialog, Tabs, Select, Input, Button, Checkbox, Badge, Separator, Scroll Area, Command.
+
+| UX Status | Notes |
+|-----------|-------|
+| Design direction | Defined — outdoor field guide aesthetic |
+| Color palette | Defined — forest green, stone gray, earth brown, campfire orange |
+| Typography | Defined — Space Grotesk headings, Source Sans 3 body |
+| Component library | Selected — shadcn/ui |
+| Mobile patterns | Defined — single column, bottom sheet nav, sticky headers |
+| Wireframes | TBD |
+| User journey maps | TBD |
+
+## 6. Functional Requirements
+
+### Event Management
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-001 | Create event | User creates an event with name, date range, departure time, return time, and expected headcount (scouts, adults, guests). | G-001 | SPL, Scoutmaster | Must | Event persisted with all fields. Date range, times, and headcount editable after creation. | BRD: BR-001 |
+| FR-002 | Trip logistics | User captures trip logistics: camping type (tent/cabin), power availability, running water, trailer access, hiking trip, cooking at altitude, expected weather. | G-002, G-003 | SPL, Scoutmaster | Must | Logistics fields visible when planning meals and selecting recipes. | BRD: BR-002 |
+| FR-003 | Meal scheduling | User defines meals for each day: breakfast, lunch, dinner, and snacks. | G-001 | SPL | Must | Each day shows meal slots. Meals can be added and removed. | BRD: BR-003 |
+| FR-004 | Meal parameters | User marks a meal as trailside or time-constrained. | G-002 | SPL | Should | Flags visible on meal and in schedule view. | BRD: BR-004 |
+| FR-005 | Multi-course meals | User indicates a meal has multiple courses (e.g., dinner with dessert). | G-002 | SPL | Should | Multiple recipes assignable to a single meal slot. | BRD: BR-005 |
+| FR-006 | Dietary restrictions | User records dietary restrictions or considerations at the meal level (e.g., nut allergy, vegetarian option needed). Never linked to individuals. | G-002 | SPL, Scoutmaster | Must | Dietary notes visible on meal in schedule view and when selecting recipes. No association with a specific person. | BRD: BR-027 |
+
+### Recipe Management
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-007 | Create recipe | User creates a recipe with name, ingredient list (item, quantity, unit), step-by-step instructions, and cooking method. | G-002, G-004 | SPL, Scout | Must | Recipe saved to library with all fields editable. | BRD: BR-006 |
+| FR-008 | Recipe equipment | User specifies required equipment: pots, pans, utensils, and supplemental items (spices, condiments). | G-003 | SPL, Scout | Must | Equipment stored with recipe and appears on event equipment list. | BRD: BR-007 |
+| FR-009 | Assign recipe to meal | User assigns a recipe from the library to a meal slot on an event. | G-001, G-002 | SPL | Must | Assigned recipe's ingredients and equipment flow into shopping and equipment lists. | BRD: BR-008 |
+| FR-010 | Recipe library | User saves a recipe to the troop library for reuse across events. | G-001 | SPL, Scout | Must | Saved recipes searchable and selectable when assigning to a meal. | BRD: BR-009 |
+| FR-011 | Recipe scaling | Recipes scale by headcount — ingredient quantities adjust proportionally. | G-002 | SPL | Must | Quantities recalculate when headcount changes. Fractions display as practical cooking measurements. | BRD: BR-010 |
+| FR-012 | Print recipe | User prints a recipe in a trip-ready format (ingredients, instructions, equipment on one page). | G-004 | Scout | Must | Browser print produces clean, readable single-recipe printout. | BRD: BR-011 |
+
+### Shopping List
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-013 | Generate shopping list | System generates a consolidated shopping list from all assigned recipes, scaled to headcount. | G-002 | SPL, Scout | Must | Duplicates combined with summed quantities. Updates when meals or headcount change. | BRD: BR-012 |
+| FR-014 | Estimated prices | Shopping list displays estimated price per item when provided. | G-002 | SPL | Should | Price column visible. Total estimated cost shown. | BRD: BR-013 |
+| FR-015 | Email shopping list | User emails the shopping list (or portion) to a specified email address. | G-005 | SPL, Scoutmaster | Must | Email sent with readable list. Recipient does not need an account. | BRD: BR-014 |
+| FR-016 | Check off purchases | Shopping list items can be checked off as purchased. | G-002 | Scout | Should | Checked state persists across sessions. | BRD: BR-015 |
+
+### Equipment List
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-017 | Generate equipment list | System generates a consolidated equipment list from all assigned recipes. | G-003 | SPL | Must | Duplicates consolidated. Updates when meal assignments change. | BRD: BR-016 |
+| FR-018 | Check off packed items | Equipment list items can be checked off as packed. | G-003 | Scout | Should | Checked state persists across sessions. | BRD: BR-017 |
+
+### Plan Sharing
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-019 | Shareable read-only link | User generates a shareable read-only link to the event plan (schedule, recipes, shopping list, equipment list). | G-005 | Scoutmaster | Must | Link accessible without login. Displays current plan state. | BRD: BR-018 |
+
+### Feedback
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-020 | Submit meal feedback | After a trip, scouts submit structured feedback: rating, portion assessment (too much / just right / too little), and free-text comments. | G-004 | Scout | Must | Feedback linked to specific meal and recipe. Multiple scouts can submit for same meal. | BRD: BR-019 |
+| FR-021 | Feedback on recipe detail | Feedback history visible on recipe in library — aggregated ratings and individual comments from past events. | G-001, G-004 | SPL | Must | Recipe detail shows past ratings and comments. | BRD: BR-020 |
+| FR-022 | Anytime feedback | Feedback submittable any time after event ends, not only at next meeting. | G-004 | Scout | Must | Feedback form available from event detail as soon as event end date passes. | BRD: BR-021 |
+
+### Safety, Compliance & Auth
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-023 | Content moderation | All user-generated text scanned by content moderation service before storage or display. | Compliance | All | Must | Offensive content flagged and not displayed. Flagged content reviewable by Scoutmaster. | BRD: BR-022 |
+| FR-024 | Youth PII minimization | Application stores only first names for youth. No email, phone, or address for minors without guardian consent. | Compliance | All | Must | Youth account creation does not require or store PII beyond first name and auth token. | BRD: BR-023 |
+| FR-025 | Admin content review | Scoutmaster has admin access to review flagged content and manage troop membership. | Compliance | Scoutmaster | Must | Admin view shows flagged items. Scoutmaster can approve, edit, or remove. | BRD: BR-024 |
+| FR-026 | Authentication | Users authenticate via Microsoft Entra ID (consumer accounts). | Compliance | All | Must | Login via MSAL. Session persists across browser refreshes. | BRD: BR-025 |
+| FR-027 | Role-based access | Scoutmaster (admin), Leader (edit), Scout (edit assigned, submit feedback), Parent (read-only via shared link). | Compliance | All | Must | Each role sees only permitted actions. Unauthorized actions rejected by API. | BRD: BR-026 |
+
+### Troop Administration
+| FR ID | Title | Description | Goals | Personas | Priority | Acceptance | Notes |
+|-------|-------|------------|-------|----------|----------|-----------|-------|
+| FR-028 | Invite members | Scoutmaster invites new members by generating an invite code or sending an invite link through the UI when adding a member. | Compliance | Scoutmaster | Must | Invite code and invite link both produce a valid join flow. New member appears in troop roster after accepting. | BRD: BR-024 |
+| FR-029 | Assign and change roles | Scoutmaster assigns or changes a member's role (Leader, Scout). | Compliance | Scoutmaster | Must | Role change takes effect immediately. Member sees updated permissions on next action. | BRD: BR-024 |
+| FR-030 | Deactivate or remove members | Scoutmaster deactivates or removes a member from the troop. Deactivated members lose access but data is retained. Removed members are permanently dissociated. | Compliance | Scoutmaster | Must | Deactivated member cannot log in to troop. Removed member no longer appears in roster. Feedback and event history attributed to deactivated members remain intact. | BRD: BR-024 |
+
+### Feature Hierarchy (Optional)
+```plain
+Scout Meal Planner MVP
+├── Event Management
+│   ├── Create/Edit Event (FR-001, FR-002)
+│   ├── Meal Scheduling (FR-003, FR-004, FR-005)
+│   └── Dietary Restrictions (FR-006)
+├── Recipe Management
+│   ├── Create/Edit Recipe (FR-007, FR-008)
+│   ├── Recipe Library (FR-010)
+│   ├── Assign to Meal (FR-009)
+│   ├── Recipe Scaling (FR-011)
+│   └── Print Recipe (FR-012)
+├── Lists
+│   ├── Shopping List (FR-013, FR-014, FR-015, FR-016)
+│   └── Equipment List (FR-017, FR-018)
+├── Communication
+│   ├── Shareable Link (FR-019)
+│   └── Email Shopping List (FR-015)
+├── Feedback
+│   ├── Submit Feedback (FR-020, FR-022)
+│   └── Feedback History (FR-021)
+├── Troop Administration
+│   ├── Invite Members (FR-028)
+│   ├── Assign Roles (FR-029)
+│   └── Deactivate/Remove Members (FR-030)
+└── Safety & Auth
+    ├── Authentication (FR-026)
+    ├── Role-Based Access (FR-027)
+    ├── Content Moderation (FR-023)
+    ├── Youth PII (FR-024)
+    └── Admin Review (FR-025)
+```
+
+## 7. Non-Functional Requirements
+| NFR ID | Category | Requirement | Metric/Target | Priority | Validation | Notes |
+|--------|----------|------------|--------------|----------|-----------|-------|
+| NFR-001 | Performance | Page load time on mobile | Responsive during meetings — no specific ms target; optimize for perceived speed on mobile | Must | Manual testing during pilot meetings; Lighthouse as guidance | MVP: optimize for feel, not a hard number |
+| NFR-002 | Performance | API response time | Fast enough not to frustrate scouts — no hard latency target | Must | Manual testing; AppInsights latency monitoring | Revisit with real usage data post-launch |
+| NFR-003 | Reliability | Application uptime | Azure SWA default (~99.95% SLA) | Must | Azure platform SLA + AppInsights availability | No custom SLA for pilot |
+| NFR-004 | Scalability | Concurrent users supported | Pilot: single troop, 20–35 users | Should | Organic pilot usage | Revisit if multi-troop added |
+| NFR-005 | Security | Authentication via Entra ID | All API calls require valid JWT | Must | Auth middleware tests | Implemented |
+| NFR-006 | Security | Content moderation latency | Non-blocking UX — moderation can run async if needed | Must | Integration testing with sandbox | |
+| NFR-007 | Privacy | Youth PII minimization | Only first name + auth token stored for minors | Must | Data audit | |
+| NFR-008 | Accessibility | WCAG 2.1 AA compliance | All color pairings meet contrast ratios | Should | axe-core audit | Color palette verified |
+| NFR-009 | Maintainability | TypeScript strict mode | Zero `any` types in production code | Must | Build-time check | Active |
+| NFR-010 | Maintainability | Test coverage | ~70% unit coverage for API, key component tests for frontend, one smoke e2e suite | Should | Vitest coverage report + Playwright smoke suite | Realistic for solo developer |
+| NFR-011 | Mobile | Mobile-first responsive design | Fully functional on mobile browsers, 44x44px touch targets | Must | Manual testing on devices | |
+| NFR-012 | Localization | English only for MVP | N/A | — | — | Post-MVP consideration |
+
+## 8. Data & Analytics (Conditional)
+### Inputs
+* Event data: name, dates, times, headcount, logistics, meal schedule, recipe assignments.
+* Recipe data: name, ingredients (item/quantity/unit), instructions, cooking method, equipment.
+* Feedback data: ratings, portion assessments, free-text comments per meal per scout.
+* User data: first name, auth token, role assignment.
+
+### Outputs / Events
+* Shopping lists: consolidated, scaled, emailable.
+* Equipment lists: consolidated from assigned recipes.
+* Shareable read-only event plan links.
+* Printable recipe pages.
+* Aggregated feedback on recipe detail pages.
+
+### Instrumentation Plan
+| Event | Trigger | Payload | Purpose | Owner |
+|-------|---------|--------|---------|-------|
+| Event created | User creates event | eventId, troopId, headcount | Track planning activity | Dev |
+| Recipe assigned | Recipe assigned to meal | eventId, recipeId, mealSlot | Track recipe reuse | Dev |
+| Shopping list emailed | User emails shopping list | eventId, recipientCount | Track communication feature usage | Dev |
+| Feedback submitted | Scout submits feedback | eventId, recipeId, rating | Track feedback engagement | Dev |
+| Content flagged | Moderation flags content | contentType, severity | Track moderation activity | Dev |
+| Shared link generated | User creates shareable link | eventId | Track sharing adoption | Dev |
+
+### Metrics & Success Criteria
+| Metric | Type | Baseline | Target | Window | Source |
+|--------|------|----------|--------|--------|--------|
+| Meeting time on meal planning | Operational | 30–60+ min | ≤15 min | By 3rd trip | Scoutmaster observation |
+| Shopping list accuracy | Operational | Errors most trips | Zero errors | By 3rd trip | Post-trip retrospective |
+| Equipment list completeness | Operational | Items forgotten most trips | Zero omissions | By 3rd trip | Post-trip retrospective |
+| Recipe availability on trip | Operational | Often incomplete | 100% accessible | By 2nd trip | Spot-check at departure |
+| User adoption rate (pilot) | Adoption | 0% | 80% active scouts | Per planning cycle | Unique logins |
+| Feedback submission rate | Engagement | Informal only | ≥50% attendees | Per trip | In-app count vs. roster |
+
+## 9. Dependencies
+| Dependency | Type | Criticality | Owner | Risk | Mitigation |
+|-----------|------|------------|-------|------|-----------|
+| Scouting America compliance review | Regulatory | High | Scoutmaster / Council | Blocks youth access | Research early; adults-only workaround possible |
+| Azure Content Safety integration | Service | High | Developer | Blocks UGC features | Manual review fallback during pilot |
+| Microsoft Entra ID (MSAL) | Service | High | Developer | Blocks multi-user access | In progress; consumer accounts |
+
+## 10. Risks & Mitigations
+| Risk ID | Description | Severity | Likelihood | Mitigation | Owner | Status |
+|---------|-------------|---------|-----------|-----------|-------|--------|
+| RSK-001 | Scouting America compliance blocks youth access | High | High | Research policies early, design for compliance, engage council contacts | Scoutmaster + Dev | Not started |
+| RSK-002 | Content moderation fails to catch inappropriate content | High | Medium | Integrate Azure Content Safety, manual review during pilot, reporting mechanism | Dev | Not started |
+| RSK-003 | Low scout adoption — revert to informal methods | High | Medium | Involve SPL in design feedback, fast mobile UX, demonstrate value on first trip | Dev + Scoutmaster | Not started |
+| RSK-004 | Single developer bottleneck delays September launch | Medium | Medium | Ruthless MVP prioritization, use shadcn/ui, accept rough edges in non-critical areas | Dev | Active |
+| RSK-005 | Poor mobile experience | Medium | Medium | Mobile-first design, test on actual scout devices during prototype | Dev | Active |
+| RSK-006 | Feedback not captured — scouts forget or skip it | Medium | Low | Enable feedback immediately after trip, in-app reminders | Dev | Not started |
+| RSK-007 | PII exposure for minor scouts | High | Low | First names only, no email/phone for minors, access controls, data retention policies | Dev | Partially addressed |
+
+## 11. Privacy, Security & Compliance
+### Data Classification
+* **Public**: Shared read-only event plans (via shareable link).
+* **Internal**: Recipes, meal schedules, shopping lists, equipment lists, event details.
+* **Sensitive**: Dietary restrictions (meal-level only, never person-linked), feedback comments, flagged content.
+* **Restricted**: Authentication tokens, user role assignments.
+
+### PII Handling
+* Youth members: first name + auth token only. No email, phone, or address without guardian consent.
+* Adult members: name + Microsoft account (via Entra ID). No additional PII stored by the application.
+* Parents: no account required — access via shareable read-only link.
+
+### Threat Considerations
+* Unauthorized access to troop data — mitigated by Entra ID auth + RBAC middleware.
+* Inappropriate content from youth users — mitigated by content moderation service.
+* PII leakage for minors — mitigated by minimal data collection and meal-level dietary restrictions.
+* Shareable link exposure — links are read-only, contain no PII, can be regenerated/revoked.
+
+### Regulatory / Compliance (Conditional)
+| Regulation | Applicability | Action | Owner | Status |
+|-----------|--------------|--------|-------|--------|
+| Scouting America technology platform policy | Required for youth-facing app | Compliance review before youth access | Scoutmaster / Council | Not started |
+| COPPA (Children's Online Privacy Protection Act) | Potentially applicable if users under 13 | Minimize PII, parental consent for minors, review data practices | Dev | Design addresses; legal review TBD |
+
+## 12. Operational Considerations
+| Aspect | Requirement | Notes |
+|--------|------------|-------|
+| Deployment | GitHub Actions CI/CD: CI on PRs (build + test), deploy on push to `main`. Frontend → Azure SWA via `static-web-apps-deploy`. API → Azure Functions via blob deploy + restart. Infra → Bicep via manual workflow dispatch. | 3 workflows: `ci.yml`, `deploy.yml`, `infra.yml`. Smart path filtering skips unchanged components. |
+| Rollback | Redeploy previous version from `main` branch | Sufficient for MVP; no blue/green or slot-based deployment needed |
+| Monitoring | Azure Application Insights | Instrument frontend and API for request tracing, latency, errors, and availability |
+| Alerting | AppInsights default alerts (failures, availability) | Fine-tune alert thresholds after pilot usage establishes baselines |
+| Support | Single developer + Scoutmaster for pilot | No formal support model for MVP |
+| Capacity Planning | Pilot: single troop (20–35 users), low RU consumption | Monitor Cosmos DB RUs via AppInsights |
+
+## 13. Rollout & Launch Plan
+### Phases / Milestones
+| Phase | Date | Gate Criteria | Owner |
+|-------|------|--------------|-------|
+| Prototype | May 2026 | Core event + recipe + list flows demo-ready; AppInsights instrumented | Dev |
+| Scouting America compliance review | May–Jun 2026 | Policy review complete, any required changes implemented | Scoutmaster + Dev |
+| Content moderation integration | Jun–Jul 2026 | Azure Content Safety active, flagging tested via sandbox | Dev |
+| Beta (adults only) | Jul–Aug 2026 | Scoutmaster + leaders can create events and plan meals end-to-end | Dev |
+| MVP Launch | September 2026 | All Must requirements pass acceptance, compliance cleared, CI green | Dev + Scoutmaster |
+
+### Feature Flags (Conditional)
+
+Feature flags enable progressive rollout, safe experimentation, and quick kill-switches without redeployment. Flags are evaluated at runtime and can be toggled per environment (dev, beta, production).
+
+**Implementation approach**: Use a simple flags configuration (e.g., environment variables or a JSON config served by the API) for MVP. Migrate to Azure App Configuration feature management if flag count or complexity grows post-MVP.
+
+**Flag lifecycle**: Each flag has a sunset criteria — once the feature is stable and fully rolled out, remove the flag and the conditional code. Stale flags add complexity.
+
+| Flag | Purpose | Default | Sunset Criteria |
+|------|---------|--------|----------------|
+| `enable-content-moderation` | Gate Azure Content Safety integration. Off during early dev; on for beta and launch. Allows fallback to manual-only review if service has issues. | Off (dev), On (beta+) | Remove after 2 successful trips with moderation active and no service issues |
+| `enable-email-shopping-list` | Gate email sending for shopping lists (FR-015). Prevents accidental emails during development and testing. | Off (dev), On (beta+) | Remove after email integration confirmed working in production |
+| `enable-shared-links` | Gate shareable read-only link generation (FR-019). Allows testing the view without exposing real links prematurely. | Off (dev), On (beta+) | Remove after first shared link successfully used by a parent |
+| `enable-feedback` | Gate post-trip feedback submission (FR-020–022). Can be turned off if content moderation is not yet active (feedback includes free text). | Off (until content moderation active) | Remove after 2 trips with feedback successfully collected |
+| `enable-print-recipes` | Gate print-formatted recipe view (FR-012). Low risk, but useful to defer print CSS work until core flows are solid. | On | Remove after print format validated on actual trip |
+
+**Principles for effective flag usage**:
+1. **One flag per independently deployable capability** — don’t bundle unrelated features behind a single flag.
+2. **Default to off for anything with external side effects** (emails, shared links, third-party API calls).
+3. **Default to on for pure UI features** that don’t affect data or external systems.
+4. **Always test both paths** — write at least one test with the flag on and one with it off.
+5. **Sunset aggressively** — once a feature is stable in production, remove the flag within the next release cycle. Dead flags are technical debt.
+6. **Log flag evaluations** — emit an AppInsights event when a flag changes user experience, so you can correlate behavior with flag state.
+
+### Communication Plan (Optional)
+1. **Scoutmaster** introduces tool at a troop meeting (beta phase).
+2. **SPL walkthrough** — developer demos core planning flow with SPL before first real use.
+3. **Parent notification** — Scoutmaster shares info via existing troop communication channel (email list / Remind app) when shared links go live.
+4. **Feedback loop** — collect informal usability feedback from SPL and Scoutmaster after first 2 trips.
+
+## 14. Open Questions
+| Q ID | Question | Owner | Deadline | Status |
+|------|----------|-------|---------|--------|
+| OQ-001 | What are Scouting America's specific technology platform requirements for youth-facing apps? | Scoutmaster | Before prototype | Open |
+| OQ-002 | ~~What performance targets are appropriate for mobile page load and API response times?~~ | Dev | — | Resolved — optimize for perceived speed, no hard targets |
+| OQ-003 | ~~What test coverage target is realistic for a solo developer?~~ | Dev | — | Resolved — ~70% API unit, key frontend components, smoke e2e |
+| OQ-004 | Should the app support COPPA compliance explicitly, or is Scouting America compliance sufficient? | Dev | Before youth access | Open |
+| OQ-005 | ~~What is the monitoring and alerting strategy for the MVP?~~ | Dev | — | Resolved — Azure Application Insights with default alerts |
+
+## 15. Changelog
+| Version | Date | Author | Summary | Type |
+|---------|------|-------|---------|------|
+| 0.1 | 2026-04-18 | andyrob | Initial PRD draft — populated from approved BRD v1.0 and existing design direction | Creation |
+| 1.0 | 2026-04-18 | andyrob | Approved — added troop admin FRs (FR-028–030), feature flags, user journeys, communication plan. 2 open questions remain (external dependencies, not blockers). | Approval |
+
+## 16. References & Provenance
+| Ref ID | Type | Source | Summary | Conflict Resolution |
+|--------|------|--------|---------|--------------------|
+| REF-001 | BRD | docs/brds/scout-meal-planner-mvp-brd.md | Approved BRD v1.0 — 27 business requirements, objectives, process flows, risks | Primary source for all functional requirements |
+| REF-002 | Design | PRD.md (root) | Original PRD with design direction — colors, fonts, components, animations, mobile patterns | Design elements preserved; feature scope replaced by BRD |
+
+### Citation Usage
+All functional requirements (FR-001 through FR-027) trace directly to BRD business requirements (BR-001 through BR-027). Design direction (Section 5 UX/UI) preserved from REF-002. Feature scope and priorities governed by REF-001.
+
+## 17. Appendices (Optional)
+### Glossary
+| Term | Definition |
+|------|-----------|
+| Troop | A local unit of scouts led by adult volunteers |
+| Scoutmaster | The primary adult leader responsible for a troop |
+| SPL (Senior Patrol Leader) | The elected youth leader of the troop who facilitates meetings and planning |
+| Patrol | A small group of scouts within a troop (typically 6–8 scouts) |
+| Event | A camping trip or multi-day activity requiring meal planning |
+| Trailside meal | A meal prepared in advance because on-site cooking is not feasible |
+| Headcount | Total people to feed: scouts + adults + guests |
+
+### Additional Notes
+**Technology stack**: React + Vite frontend, Azure Functions v4 (Node.js) API, Azure Cosmos DB, Azure Static Web App, Microsoft Entra ID (MSAL), Tailwind CSS, shadcn/ui, TanStack Query, Zod schemas, Vitest + Playwright.
+
+Generated 2026-04-18 by PRD Builder (mode: iterative)
+<!-- markdown-table-prettify-ignore-end -->

--- a/docs/prds/scout-meal-planner-mvp.md
+++ b/docs/prds/scout-meal-planner-mvp.md
@@ -111,6 +111,7 @@ Continued meeting time waste (30–60+ min per trip), repeated shopping errors, 
 
 ### Out of Scope (justify if empty)
 * Multi-troop-per-user support and cross-troop recipe sharing — post-MVP when pilot validates the model. Multi-troop will introduce a new admin role for approving new troops. Note: the current architecture is already multi-tenant (multiple troops coexist safely with data isolated by `troopId`); what is deferred is allowing a single user to belong to more than one troop with a troop-switcher UI.
+* Dedicated parent role with activity reports and self-service data deletion — post-MVP. For the pilot, parental consent is handled via Microsoft Family accounts and admin-assisted deletion (see Section 11).
 * Patrol management within the app — one scout records information; patrol structure is managed offline.
 * In-app brainstorming and voting — SPL records decisions made during in-person discussion.
 * Individual scout shopper assignment in-app — shopping lists are emailed instead.
@@ -245,6 +246,7 @@ A purpose-built meal planning tool for scout troops that preserves scout-led pla
 | FR-028 | Invite members | Scoutmaster invites new members by generating an invite code or sending an invite link through the UI when adding a member. | Compliance | Scoutmaster | Must | Invite code and invite link both produce a valid join flow. New member appears in troop roster after accepting. | BRD: BR-024 |
 | FR-029 | Assign and change roles | Scoutmaster assigns or changes a member's role (Leader, Scout). | Compliance | Scoutmaster | Must | Role change takes effect immediately. Member sees updated permissions on next action. | BRD: BR-024 |
 | FR-030 | Deactivate or remove members | Scoutmaster deactivates or removes a member from the troop. Deactivated members lose access but data is retained. Removed members are permanently dissociated. | Compliance | Scoutmaster | Must | Deactivated member cannot log in to troop. Removed member no longer appears in roster. Feedback and event history attributed to deactivated members remain intact. | BRD: BR-024 |
+| FR-031 | Delete member data | Troop admin deletes all data associated with a specific member across all containers (feedback, event audit trails, membership record). Supports COPPA parental deletion requests. | Compliance | Scoutmaster | Must | After deletion, no records attributable to the member remain. Feedback from deleted members is either anonymized or removed. Confirmation prompt before execution. | COPPA compliance |
 
 ### Feature Hierarchy (Optional)
 ```plain
@@ -360,6 +362,17 @@ Scout Meal Planner MVP
 * Adult members: name + Microsoft account (via Entra ID). No additional PII stored by the application.
 * Parents: no account required — access via shareable read-only link.
 
+### COPPA Consent Model (MVP)
+The application collects minimal data from scouts (first name and auth token via Microsoft Entra ID). The MVP consent model relies on three controls:
+
+1. **Microsoft Family accounts** — Scouts under 13 must use a Microsoft account managed by a parent/guardian. The parent controls the account and can revoke access at any time. Microsoft's own COPPA-compliant family consent flow applies at account creation.
+2. **Consent notice at join** — When a scout joins a troop via invite code, the app displays a consent notice: "By joining, a parent/guardian confirms they consent to data collection as described in our privacy policy." The invite code itself is distributed by the troop leader to parents, establishing an offline consent chain.
+3. **Admin-assisted data deletion** — Troop admin can delete all data associated with a specific member (FR-031) on behalf of a parental request. For the pilot, a "Request Data Deletion" link in the privacy policy provides an email-based fallback.
+
+**Deferred to post-MVP**: Dedicated parent role with self-service activity reports and data deletion UI. For the pilot (single troop, known families), admin-assisted deletion is sufficient.
+
+See [Privacy Policy](../policies/privacy-policy.md) for the full data handling reference.
+
 ### Threat Considerations
 * Unauthorized access to troop data — mitigated by Entra ID auth + RBAC middleware.
 * Inappropriate content from youth users — mitigated by content moderation service.
@@ -428,7 +441,7 @@ Feature flags enable progressive rollout, safe experimentation, and quick kill-s
 | OQ-001 | What are Scouting America's specific technology platform requirements for youth-facing apps? | Scoutmaster | Before prototype | Open |
 | OQ-002 | ~~What performance targets are appropriate for mobile page load and API response times?~~ | Dev | — | Resolved — optimize for perceived speed, no hard targets |
 | OQ-003 | ~~What test coverage target is realistic for a solo developer?~~ | Dev | — | Resolved — ~70% API unit, key frontend components, smoke e2e |
-| OQ-004 | Should the app support COPPA compliance explicitly, or is Scouting America compliance sufficient? | Dev | Before youth access | Open |
+| OQ-004 | ~~Should the app support COPPA compliance explicitly, or is Scouting America compliance sufficient?~~ | Dev | — | Resolved — MVP uses Microsoft Family accounts for parental consent, consent notice at join, admin-assisted data deletion (FR-031), and a privacy policy. Dedicated parent role deferred to post-MVP. |
 | OQ-005 | ~~What is the monitoring and alerting strategy for the MVP?~~ | Dev | — | Resolved — Azure Application Insights with default alerts |
 
 ## 15. Changelog
@@ -436,6 +449,7 @@ Feature flags enable progressive rollout, safe experimentation, and quick kill-s
 |---------|------|-------|---------|------|
 | 0.1 | 2026-04-18 | andyrob | Initial PRD draft — populated from approved BRD v1.0 and existing design direction | Creation |
 | 1.0 | 2026-04-18 | andyrob | Approved — added troop admin FRs (FR-028–030), feature flags, user journeys, communication plan. 2 open questions remain (external dependencies, not blockers). | Approval |
+| 1.1 | 2026-04-18 | andyrob | Added COPPA consent model (Section 11), FR-031 (member data deletion), resolved OQ-004, added parent role to out-of-scope, linked privacy policy. | Update |
 
 ## 16. References & Provenance
 | Ref ID | Type | Source | Summary | Conflict Resolution |

--- a/docs/templates/brd-template.md
+++ b/docs/templates/brd-template.md
@@ -1,0 +1,121 @@
+---
+title: "{{title}}"
+description: "{{description}}"
+author: "{{author}}"
+ms.date: "{{date}}"
+ms.topic: "business-requirements-document"
+---
+
+# {{title}}
+
+## Document Control
+
+| Field | Value |
+|---|---|
+| **Version** | {{version}} |
+| **Status** | {{status}} |
+| **Author** | {{author}} |
+| **Date** | {{date}} |
+| **Approvers** | {{approvers}} |
+
+## Business Context and Background
+
+{{business_context}}
+
+## Problem Statement and Business Drivers
+
+### Problem Statement
+
+{{problem_statement}}
+
+### Business Drivers
+
+{{business_drivers}}
+
+## Business Objectives and Success Metrics
+
+### Objectives
+
+| ID | Objective | Measure | Baseline | Target | Timeframe |
+|---|---|---|---|---|---|
+| OBJ-001 | {{objective}} | {{measure}} | {{baseline}} | {{target}} | {{timeframe}} |
+
+### Key Performance Indicators
+
+| KPI | Baseline | Target | Measurement Method |
+|---|---|---|---|
+| {{kpi}} | {{baseline}} | {{target}} | {{method}} |
+
+## Stakeholders and Roles
+
+| Stakeholder | Role | Interest | Impact Level |
+|---|---|---|---|
+| {{stakeholder}} | {{role}} | {{interest}} | {{impact}} |
+
+## Scope
+
+### In Scope
+
+{{in_scope}}
+
+### Out of Scope
+
+{{out_of_scope}}
+
+### Assumptions
+
+{{assumptions}}
+
+### Constraints
+
+{{constraints}}
+
+## Business Requirements
+
+| ID | Requirement | Linked Objective | Priority | Acceptance Criteria |
+|---|---|---|---|---|
+| BR-001 | {{requirement}} | {{linked_objective}} | {{priority}} | {{acceptance_criteria}} |
+
+## Current and Future Business Processes
+
+### Current State (As-Is)
+
+{{current_state}}
+
+### Future State (To-Be)
+
+{{future_state}}
+
+## Data and Reporting Requirements
+
+{{data_requirements}}
+
+## Benefits and High-Level Economics
+
+### Quantitative Benefits
+
+{{quantitative_benefits}}
+
+### Qualitative Benefits
+
+{{qualitative_benefits}}
+
+### Cost Considerations
+
+{{cost_considerations}}
+
+## Risks and Mitigations
+
+| ID | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| RSK-001 | {{risk}} | {{likelihood}} | {{impact}} | {{mitigation}} |
+
+## Dependencies
+
+{{dependencies}}
+
+## Glossary
+
+| Term | Definition |
+|---|---|
+| {{term}} | {{definition}} |


### PR DESCRIPTION
## Summary

Adds the complete planning documentation suite for the Scout Meal Planner MVP: approved BRD, comprehensive PRD (v1.2), and a privacy policy.

## What Changed

### Business Requirements Document
- `docs/brds/scout-meal-planner-mvp-brd.md` — Approved BRD v1.0 with 27 business requirements, objectives, process flows, and risks.

### Product Requirements Document
- `docs/prds/scout-meal-planner-mvp.md` — PRD v1.2 with:
  - 31 functional requirements (FR-001–FR-031) traced to BRD
  - 12 non-functional requirements
  - 5 feature flags for incremental rollout
  - RBAC model (5 roles, 6 permissions)
  - COPPA consent model (Microsoft Family accounts, consent notice at join, admin-assisted deletion)
  - Scouting America compliance mapping across 5 policy areas (Youth Protection, Digital Safety, Cyber Chip, age-appropriate access, approved platforms)
  - All 5 open questions resolved
  - Gap analysis completed (13 Built, 5 Partial, 12 Missing)

### Privacy Policy
- `docs/policies/privacy-policy.md` — Data handling reference covering data inventory, COPPA controls, retention, sharing, and an agent/developer decision reference section.

## Key Decisions
- **COPPA**: MVP uses Microsoft Family accounts + consent notice + admin-assisted deletion (FR-031). Dedicated parent role deferred to post-MVP.
- **Scouting America**: No prescriptive tech checklist exists; compliance is policy-based. PRD addresses all 5 policy areas by design.
- **Multi-troop per user**: Architecture is multi-tenant (data isolated by troopId). Troop switcher UI deferred to post-MVP.

## References
- REF-001: Approved BRD v1.0
- REF-002: Original PRD design direction
- REF-003–REF-006: Scouting America policy sources (scouting.org)