### PR TITLE
feat: add time-gating to anytime feedback (#52)

### DIFF
--- a/src/components/EventFeedback.tsx
+++ b/src/components/EventFeedback.tsx
@@ -1,8 +1,9 @@
 import { useState, useRef } from 'react'
 import { Event, Recipe, MealFeedback, FeedbackRating } from '@/lib/types'
+import { hasEventEnded } from '@/lib/helpers'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { ChatCircle, Plus, Camera, X, Image as ImageIcon, User, PencilSimple, Trash, ClockCounterClockwise } from '@phosphor-icons/react'
+import { ChatCircle, Plus, Camera, X, Image as ImageIcon, User, PencilSimple, Trash, ClockCounterClockwise, Clock } from '@phosphor-icons/react'
 import {
   Dialog,
   DialogContent,
@@ -55,6 +56,7 @@ export function EventFeedback({ event, recipes, feedback, onAddFeedback, onUpdat
   })
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  const feedbackEnabled = hasEventEnded(event)
   const eventFeedback = feedback.filter(f => f.eventId === event.id)
 
   const allMeals = event.days.flatMap((day, dayIndex) =>
@@ -184,11 +186,22 @@ export function EventFeedback({ event, recipes, feedback, onAddFeedback, onUpdat
           <h2 className="text-2xl font-semibold mb-2">Meal Feedback</h2>
           <p className="text-muted-foreground">Collect feedback to improve future meals</p>
         </div>
-        <Button onClick={() => handleOpenDialog()} className="gap-2">
+        <Button onClick={() => handleOpenDialog()} className="gap-2" disabled={!feedbackEnabled}>
           <Plus size={20} />
           Add Feedback
         </Button>
       </div>
+
+      {!feedbackEnabled && (
+        <Card className="border-dashed">
+          <CardContent className="flex items-center gap-3 py-4">
+            <Clock size={20} className="text-muted-foreground flex-shrink-0" />
+            <p className="text-sm text-muted-foreground">
+              Feedback can be submitted once the event has ended ({event.endDate}).
+            </p>
+          </CardContent>
+        </Card>
+      )}
 
       {eventFeedback.length === 0 ? (
         <Card>

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   migrateRecipeToVersioning,
   isRecipeInEvent,
   isEventActive,
+  hasEventEnded,
   getRecipeEventVersion,
   shouldCreateNewVersion,
   calculateRecipeRatings,
@@ -355,6 +356,27 @@ describe('isEventActive', () => {
     const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}T00:00:00`
     const event = makeEvent({ endDate: today })
     expect(isEventActive(event)).toBe(true)
+  })
+})
+
+// ── hasEventEnded ──
+
+describe('hasEventEnded', () => {
+  it('returns true for past event (feedback eligible)', () => {
+    const event = makeEvent({ endDate: '2020-01-01' })
+    expect(hasEventEnded(event)).toBe(true)
+  })
+
+  it('returns false for future event (feedback not yet eligible)', () => {
+    const event = makeEvent({ endDate: '2099-12-31' })
+    expect(hasEventEnded(event)).toBe(false)
+  })
+
+  it('returns false for event ending today (still active)', () => {
+    const now = new Date()
+    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}T00:00:00`
+    const event = makeEvent({ endDate: today })
+    expect(hasEventEnded(event)).toBe(false)
   })
 })
 

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -205,6 +205,11 @@ export function isEventActive(event: Event): boolean {
   return today <= endDate
 }
 
+/** Returns true when the event end date has passed (feedback is eligible). */
+export function hasEventEnded(event: Event): boolean {
+  return !isEventActive(event)
+}
+
 export function getRecipeEventVersion(recipe: Recipe, eventId: string): RecipeVersion | undefined {
   return recipe.versions.find(v => v.eventId === eventId)
 }


### PR DESCRIPTION
Closes #52

## Changes
- Added \hasEventEnded()\ helper in \src/lib/helpers.ts\ — returns true when event end date has passed
- Updated \EventFeedback.tsx\ to disable the **Add Feedback** button for events that haven't ended yet
- Added an informational banner showing the event end date when feedback is not yet available
- Added 3 unit tests for the new helper (past, future, and same-day events)

## Acceptance Criteria
- [x] Feedback form available from event detail as soon as event end date passes
- [x] No arbitrary deadline for feedback submission
- [x] Feedback button disabled/hidden for future events

Build: ✅ | Tests: 69 passing ✅