### PR TITLE
fix: toggle publicNetworkAccess in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,6 +126,7 @@ jobs:
           az storage account update \
             --name stscoutmealplanner \
             --resource-group rg-scout-meal-planner \
+            --public-network-access Enabled \
             --default-action Allow
           sleep 30
 
@@ -145,7 +146,8 @@ jobs:
           az storage account update \
             --name stscoutmealplanner \
             --resource-group rg-scout-meal-planner \
-            --default-action Deny
+            --default-action Deny \
+            --public-network-access Disabled
 
       - name: Trigger function app deployment sync
         run: |


### PR DESCRIPTION
The deploy workflow was only toggling \defaultAction\ but the storage account also has \publicNetworkAccess: Disabled\ (enforced by Azure Policy). This adds \--public-network-access Enabled/Disabled\ to the open/close firewall steps so deploys succeed without leaving the storage permanently open.