### PR TITLE
feat: add flagged content count badge to admin dashboard

### DIFF
--- a/src/components/TroopAdmin.test.tsx
+++ b/src/components/TroopAdmin.test.tsx
@@ -131,6 +131,31 @@ describe('TroopAdmin member data deletion', () => {
     })
   })
 
+  it('shows flagged content count badge when items are flagged', async () => {
+    adminApiMock.getFlaggedContent.mockResolvedValueOnce([
+      {
+        id: 'feedback:f1',
+        contentId: 'f1',
+        contentType: 'feedback',
+        flagReason: 'Flagged fields: comments',
+        flaggedAt: 1700000000000,
+        context: { comments: 'Bad comment' },
+      },
+      {
+        id: 'recipe:r1',
+        contentId: 'r1',
+        contentType: 'recipe',
+        flagReason: 'Flagged fields: name',
+        flaggedAt: 1700000000000,
+        context: { name: 'Bad name' },
+      },
+    ])
+
+    renderTroopAdmin()
+
+    await waitFor(() => expect(screen.getByText('2')).toBeInTheDocument())
+  })
+
   it('shows flagged content and allows approving it', async () => {
     const user = userEvent.setup()
     adminApiMock.getFlaggedContent.mockResolvedValueOnce([

--- a/src/components/TroopAdmin.tsx
+++ b/src/components/TroopAdmin.tsx
@@ -461,7 +461,12 @@ export function TroopAdmin() {
       {/* Flagged Content Review */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-lg">Flagged Content Review</CardTitle>
+          <CardTitle className="text-lg">
+            Flagged Content Review
+            {(flaggedContentQuery.data || []).length > 0 && (
+              <Badge variant="destructive" className="ml-2">{flaggedContentQuery.data!.length}</Badge>
+            )}
+          </CardTitle>
           <CardDescription>Review content flagged by moderation</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">


### PR DESCRIPTION
## Summary

Adds a destructive Badge showing the count of flagged content items next to the **Flagged Content Review** heading in the TroopAdmin dashboard. The badge only renders when there is at least one flagged item.

## Changes

- **src/components/TroopAdmin.tsx** — Added count Badge to the Flagged Content Review CardTitle
- **src/components/TroopAdmin.test.tsx** — Added test verifying the count badge displays correctly with multiple flagged items

## Testing

- Frontend build: passes
- Frontend tests: 107/107 pass
- API build: passes
- API tests: 147/147 pass

Closes #55