### PR TITLE
infra: replace SendGrid with Azure Communication Services

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -31,9 +31,6 @@ jobs:
             --location centralus \
             --template-file infra/main.bicep \
             --parameters infra/parameters.json \
-            --parameters sendGridEmail='${{ secrets.SENDGRID_EMAIL }}' \
-                         sendGridPassword='${{ secrets.SENDGRID_PASSWORD }}' \
-                         sendGridApiKey='${{ secrets.SENDGRID_API_KEY }}' \
             --name "scout-meal-planner-$(date +%Y%m%d%H%M%S)" \
             --query "properties.outputs" -o json)
           echo "SWA URL: $(echo $result | jq -r '.staticWebAppUrl.value')"

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -10,9 +10,6 @@ az deployment sub create \
   --location centralus \
   --template-file "$SCRIPT_DIR/main.bicep" \
   --parameters "$SCRIPT_DIR/parameters.json" \
-  --parameters sendGridEmail="$SENDGRID_EMAIL" \
-               sendGridPassword="$SENDGRID_PASSWORD" \
-               sendGridApiKey="$SENDGRID_API_KEY" \
   --name "scout-meal-planner-$(date +%Y%m%d%H%M%S)"
 
 echo ""

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -33,19 +33,8 @@ param deployerPrincipalId string = ''
 @description('Name of the Azure AI Content Safety account')
 param contentSafetyAccountName string = 'cs-scout-meal-planner'
 
-@description('Name of the SendGrid account')
-param sendGridAccountName string = 'sg-scout-meal-planner'
-
-@description('Email address for SendGrid account administration')
-param sendGridEmail string = ''
-
-@secure()
-@description('Password for the SendGrid account')
-param sendGridPassword string = ''
-
-@secure()
-@description('SendGrid API key (generate in the SendGrid portal after provisioning)')
-param sendGridApiKey string = ''
+@description('Name of the Azure Communication Services resource')
+param communicationServiceName string = 'acs-scout-meal-planner'
 
 resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
   name: resourceGroupName
@@ -66,10 +55,7 @@ module resources 'resources.bicep' = {
     storageAccountName: storageAccountName
     deployerPrincipalId: deployerPrincipalId
     contentSafetyAccountName: contentSafetyAccountName
-    sendGridAccountName: sendGridAccountName
-    sendGridEmail: sendGridEmail
-    sendGridPassword: sendGridPassword
-    sendGridApiKey: sendGridApiKey
+    communicationServiceName: communicationServiceName
   }
 }
 
@@ -78,4 +64,4 @@ output cosmosAccountEndpoint string = resources.outputs.cosmosAccountEndpoint
 output functionAppName string = resources.outputs.functionAppName
 output msaAppClientId string = resources.outputs.msaAppClientId
 output contentSafetyEndpoint string = resources.outputs.contentSafetyEndpoint
-output sendGridAccountName string = resources.outputs.sendGridAccountName
+output acsEndpoint string = resources.outputs.acsEndpoint

--- a/infra/parameters.json
+++ b/infra/parameters.json
@@ -29,11 +29,8 @@
     "contentSafetyAccountName": {
       "value": "cs-scout-meal-planner"
     },
-    "sendGridAccountName": {
-      "value": "sg-scout-meal-planner"
-    },
-    "sendGridEmail": {
-      "value": ""
+    "communicationServiceName": {
+      "value": "acs-scout-meal-planner"
     }
   }
 }

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -40,19 +40,8 @@ param instanceMemoryMB int = 2048
 @description('Name of the Azure AI Content Safety account')
 param contentSafetyAccountName string
 
-@description('Name of the SendGrid account')
-param sendGridAccountName string
-
-@description('Email address for SendGrid account administration')
-param sendGridEmail string
-
-@secure()
-@description('Password for the SendGrid account')
-param sendGridPassword string
-
-@secure()
-@description('SendGrid API key (generate in the SendGrid portal after provisioning)')
-param sendGridApiKey string = ''
+@description('Name of the Azure Communication Services resource')
+param communicationServiceName string
 
 // Cosmos DB Account — Serverless
 resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
@@ -97,7 +86,7 @@ resource eventsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/con
     resource: {
       id: 'events'
       partitionKey: {
-        paths: ['/troopId']
+        paths: ['/id']
         kind: 'Hash'
       }
     }
@@ -112,7 +101,7 @@ resource recipesContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/co
     resource: {
       id: 'recipes'
       partitionKey: {
-        paths: ['/troopId']
+        paths: ['/id']
         kind: 'Hash'
       }
     }
@@ -127,7 +116,7 @@ resource feedbackContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/c
     resource: {
       id: 'feedback'
       partitionKey: {
-        paths: ['/troopId']
+        paths: ['/eventId']
         kind: 'Hash'
       }
     }
@@ -246,7 +235,7 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
         { name: 'COSMOS_DATABASE', value: cosmosDatabaseName }
         { name: 'ENTRA_CLIENT_ID', value: msaApp.appId }
         { name: 'CONTENT_SAFETY_ENDPOINT', value: contentSafety.properties.endpoint }
-        { name: 'SENDGRID_API_KEY', value: sendGridApiKey }
+        { name: 'ACS_ENDPOINT', value: communicationService.properties.hostName }
       ]
     }
     httpsOnly: true
@@ -389,19 +378,23 @@ resource contentSafetyRoleAssignment 'Microsoft.Authorization/roleAssignments@20
   }
 }
 
-// ── SendGrid Email (Azure Marketplace — Free tier) ──
-resource sendGrid 'Sendgrid.Email/accounts@2015-01-01' = {
-  name: sendGridAccountName
-  location: location
-  plan: {
-    name: 'free'
-    publisher: 'Sendgrid'
-    product: 'sendgrid_azure'
-  }
+// ── Azure Communication Services ──
+resource communicationService 'Microsoft.Communication/communicationServices@2023-06-01-preview' = {
+  name: communicationServiceName
+  location: 'global'
   properties: {
-    password: sendGridPassword
-    acceptMarketingEmails: false
-    email: sendGridEmail
+    dataLocation: 'United States'
+  }
+}
+
+// Contributor role for Function App managed identity on ACS
+resource acsRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(communicationService.id, functionApp.id, 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+  scope: communicationService
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+    principalId: functionApp.identity.principalId
+    principalType: 'ServicePrincipal'
   }
 }
 
@@ -410,4 +403,4 @@ output cosmosAccountEndpoint string = cosmosAccount.properties.documentEndpoint
 output functionAppName string = functionApp.name
 output msaAppClientId string = msaApp.appId
 output contentSafetyEndpoint string = contentSafety.properties.endpoint
-output sendGridAccountName string = sendGrid.name
+output acsEndpoint string = communicationService.properties.hostName


### PR DESCRIPTION
## Summary

Removes the SendGrid marketplace resource (which failed deployment due to unavailable namespace) and replaces it with Azure Communication Services.

## Changes

- **Remove** \Sendgrid.Email/accounts\ resource, all associated params, secrets, and outputs
- **Add** \Microsoft.Communication/communicationServices\ (global location, US data residency)
- **Add** Contributor RBAC assignment for Function App managed identity on ACS
- **Wire** \ACS_ENDPOINT\ app setting into Function App (replacing \SENDGRID_API_KEY\)
- **Fix** Cosmos DB partition keys to match live containers (\/id\ for events/recipes/troops, \/eventId\ for feedback, \/troopId\ for members)
- **Clean up** workflow and deploy script (no more SendGrid secrets needed)

## Testing

- Bicep lints clean (no errors)
- Ready for infra workflow dispatch after merge