### PR TITLE
infra: remove Graph extension, parameterize Entra client ID

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -36,6 +36,9 @@ param contentSafetyAccountName string = 'cs-scout-meal-planner'
 @description('Name of the Azure Communication Services resource')
 param communicationServiceName string = 'acs-scout-meal-planner'
 
+@description('Client ID of the pre-created Entra app registration for MSAL sign-in')
+param entraClientId string = '42871bb7-a693-4d97-9cb9-69bbf9a50ff4'
+
 resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
   name: resourceGroupName
   location: location
@@ -54,6 +57,7 @@ module resources 'resources.bicep' = {
     functionAppName: functionAppName
     storageAccountName: storageAccountName
     deployerPrincipalId: deployerPrincipalId
+    entraClientId: entraClientId
     contentSafetyAccountName: contentSafetyAccountName
     communicationServiceName: communicationServiceName
   }
@@ -62,6 +66,6 @@ module resources 'resources.bicep' = {
 output staticWebAppUrl string = resources.outputs.staticWebAppUrl
 output cosmosAccountEndpoint string = resources.outputs.cosmosAccountEndpoint
 output functionAppName string = resources.outputs.functionAppName
-output msaAppClientId string = resources.outputs.msaAppClientId
+output entraClientId string = resources.outputs.entraClientId
 output contentSafetyEndpoint string = resources.outputs.contentSafetyEndpoint
 output acsEndpoint string = resources.outputs.acsEndpoint

--- a/infra/parameters.json
+++ b/infra/parameters.json
@@ -26,6 +26,9 @@
     "deployerPrincipalId": {
       "value": "c96e135f-f098-489f-bb15-07894d415ebe"
     },
+    "entraClientId": {
+      "value": "42871bb7-a693-4d97-9cb9-69bbf9a50ff4"
+    },
     "contentSafetyAccountName": {
       "value": "cs-scout-meal-planner"
     },

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -1,5 +1,3 @@
-extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview'
-
 @description('Azure region for all resources')
 param location string
 
@@ -27,8 +25,8 @@ param storageAccountName string
 @description('Object ID of the GitHub Actions service principal for deployment')
 param deployerPrincipalId string = ''
 
-@description('Display name for the MSA sign-in app registration')
-param msaAppDisplayName string = 'ScoutMealPlanner'
+@description('Client ID of the pre-created Entra app registration for MSAL sign-in')
+param entraClientId string
 
 @description('Maximum instance count for Flex Consumption scaling')
 param maximumInstanceCount int = 100
@@ -233,7 +231,7 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
         { name: 'AzureWebJobsStorage__tableServiceUri', value: 'https://${storageAccount.name}.table.${environment().suffixes.storage}' }
         { name: 'COSMOS_ENDPOINT', value: cosmosAccount.properties.documentEndpoint }
         { name: 'COSMOS_DATABASE', value: cosmosDatabaseName }
-        { name: 'ENTRA_CLIENT_ID', value: msaApp.appId }
+        { name: 'ENTRA_CLIENT_ID', value: entraClientId }
         { name: 'CONTENT_SAFETY_ENDPOINT', value: contentSafety.properties.endpoint }
         { name: 'ACS_ENDPOINT', value: communicationService.properties.hostName }
       ]
@@ -340,19 +338,6 @@ resource swaBackend 'Microsoft.Web/staticSites/linkedBackends@2023-12-01' = {
   }
 }
 
-// ── App Registration: MSA sign-in (Personal Microsoft Accounts only) ──
-resource msaApp 'Microsoft.Graph/applications@v1.0' = {
-  uniqueName: msaAppDisplayName
-  displayName: msaAppDisplayName
-  signInAudience: 'PersonalMicrosoftAccount'
-  spa: {
-    redirectUris: [
-      'http://localhost:5000'
-      'https://${staticWebApp.properties.defaultHostname}'
-    ]
-  }
-}
-
 // ── Azure AI Content Safety ──
 resource contentSafety 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
   name: contentSafetyAccountName
@@ -401,6 +386,6 @@ resource acsRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' 
 output staticWebAppUrl string = staticWebApp.properties.defaultHostname
 output cosmosAccountEndpoint string = cosmosAccount.properties.documentEndpoint
 output functionAppName string = functionApp.name
-output msaAppClientId string = msaApp.appId
+output entraClientId string = entraClientId
 output contentSafetyEndpoint string = contentSafety.properties.endpoint
 output acsEndpoint string = communicationService.properties.hostName


### PR DESCRIPTION
## Summary

Removes the Microsoft Graph Bicep extension and app registration resource that was failing with 'Insufficient privileges'. The existing app registration is now referenced by client ID parameter instead of being managed by Bicep.

## Why

The GitHub Actions service principal lacks \Application.ReadWrite.All\ permission needed by the Graph extension. Rather than granting elevated permissions, we parameterize the already-created app registration.

## Changes

- Remove \microsoftgraph/v1.0\ Bicep extension import
- Remove \msaApp\ resource (\Microsoft.Graph/applications\)
- Add \ntraClientId\ param (defaults to \42871bb7-a693-4d97-9cb9-69bbf9a50ff4\)
- Wire \ENTRA_CLIENT_ID\ Function App setting from parameter
- Update parameters.json with client ID value

## Testing

- Bicep lints clean
- Should unblock deployment (removes the only remaining known failure)