### PR TITLE
feat(api): replace SendGrid with Azure Communication Services Email

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -5,6 +5,6 @@ ENTRA_CLIENT_ID=your-client-id
 # COSMOS_ENDPOINT=https://your-account.documents.azure.com:443/
 # COSMOS_DATABASE=scout-meal-planner
 
-# SendGrid email delivery (required for shopping list email endpoint)
-# SENDGRID_API_KEY=your-sendgrid-api-key
-# SENDGRID_FROM_EMAIL=no-reply@example.com
+# Azure Communication Services email delivery (required for shopping list email endpoint)
+# ACS_ENDPOINT=acs-scout-meal-planner.unitedstates.communication.azure.com
+# ACS_FROM_EMAIL=DoNotReply@your-acs-domain.azurecomm.net

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8,6 +8,7 @@
       "name": "scout-meal-planner-api",
       "version": "1.0.0",
       "dependencies": {
+        "@azure/communication-email": "^1.1.0",
         "@azure/cosmos": "^4.9.2",
         "@azure/functions": "^4.6.0",
         "@azure/identity": "^4.13.1",
@@ -51,6 +52,46 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/communication-common": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@azure/communication-common/-/communication-common-2.4.0.tgz",
+      "integrity": "sha512-wwn4AoOgTgoA9OZkO34SKBpQg7/kfcABnzbaYEbc+9bCkBtwwjgMEk6xM+XLEE/uuODZ8q8jidUoNcZHQyP5AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-rest/core-client": "^2.3.3",
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "events": "^3.3.0",
+        "jwt-decode": "^4.0.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/communication-email": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/communication-email/-/communication-email-1.1.0.tgz",
+      "integrity": "sha512-n9ATpXyxb4MIhEp/Vtv5BU8GdUZH0vYpm/1pKXVu9AeiQ78MG3OIaiQQ2PmQfA0XPdTx5/g+tUxkwVuD6U4u4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/communication-common": "^2.3.1",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-lro": "^2.7.2",
+        "@azure/core-rest-pipeline": "^1.18.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-auth": {
@@ -1854,6 +1895,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2009,6 +2059,15 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/lodash.includes": {

--- a/api/package.json
+++ b/api/package.json
@@ -9,6 +9,7 @@
     "start": "func start"
   },
   "dependencies": {
+    "@azure/communication-email": "^1.1.0",
     "@azure/cosmos": "^4.9.2",
     "@azure/functions": "^4.6.0",
     "@azure/identity": "^4.13.1",

--- a/api/src/functions/emailShoppingList.test.ts
+++ b/api/src/functions/emailShoppingList.test.ts
@@ -25,13 +25,19 @@ vi.mock('../middleware/auth.js', async () => {
   }
 })
 
+vi.mock('@azure/communication-email', () => ({
+  EmailClient: vi.fn(),
+}))
+
+vi.mock('@azure/identity', () => ({
+  DefaultAzureCredential: vi.fn(),
+}))
+
 import * as cosmos from '../cosmosdb.js'
 import { getTroopContext } from '../middleware/auth.js'
-import './emailShoppingList.js'
+import { _setEmailClient } from './emailShoppingList.js'
 
 const handler = registeredHandlers['emailShoppingList'] as (req: HttpRequest, ctx: any) => Promise<any>
-const fetchMock = vi.fn()
-vi.stubGlobal('fetch', fetchMock)
 
 function makeReq(body: any, id = 'event-1'): HttpRequest {
   return {
@@ -53,15 +59,23 @@ const scoutAuth = {
 
 const originalEnv = { ...process.env }
 
+const mockPollUntilDone = vi.fn()
+const mockBeginSend = vi.fn()
+const mockEmailClient = { beginSend: mockBeginSend } as any
+
 beforeEach(() => {
   vi.clearAllMocks()
-  process.env.SENDGRID_API_KEY = 'test-key'
-  process.env.SENDGRID_FROM_EMAIL = 'from@example.com'
+  process.env.ACS_ENDPOINT = 'acs-scout-meal-planner.unitedstates.communication.azure.com'
+  process.env.ACS_FROM_EMAIL = 'DoNotReply@acs-scout-meal-planner.azurecomm.net'
+  _setEmailClient(mockEmailClient)
+  mockBeginSend.mockResolvedValue({ pollUntilDone: mockPollUntilDone })
+  mockPollUntilDone.mockResolvedValue({ status: 'Succeeded' })
   vi.mocked(cosmos.getById).mockResolvedValue({ id: 'event-1', troopId: 'troop-42', name: 'Campout' } as any)
 })
 
 afterEach(() => {
   process.env = { ...originalEnv }
+  _setEmailClient(undefined)
 })
 
 describe('email shopping list handler', () => {
@@ -75,7 +89,7 @@ describe('email shopping list handler', () => {
     vi.mocked(getTroopContext).mockResolvedValueOnce(scoutAuth)
     const result = await handler(makeReq({ recipientEmail: 'bad' }), ctx)
     expect(result.status).toBe(400)
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(mockBeginSend).not.toHaveBeenCalled()
   })
 
   it('returns 404 when event is not found', async () => {
@@ -86,12 +100,12 @@ describe('email shopping list handler', () => {
       items: [{ name: 'Beans', quantity: 2, unit: 'can' }],
     }), ctx)
     expect(result.status).toBe(404)
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(mockBeginSend).not.toHaveBeenCalled()
   })
 
   it('returns 500 when email service env vars are missing', async () => {
     vi.mocked(getTroopContext).mockResolvedValueOnce(scoutAuth)
-    delete process.env.SENDGRID_API_KEY
+    delete process.env.ACS_FROM_EMAIL
     const result = await handler(makeReq({
       recipientEmail: 'parent@example.com',
       items: [{ name: 'Beans', quantity: 2, unit: 'can' }],
@@ -100,9 +114,8 @@ describe('email shopping list handler', () => {
     expect(result.jsonBody.error).toBe('Email service not configured')
   })
 
-  it('sends a formatted shopping list email', async () => {
+  it('sends a formatted shopping list email via ACS', async () => {
     vi.mocked(getTroopContext).mockResolvedValueOnce(scoutAuth)
-    fetchMock.mockResolvedValueOnce({ ok: true, status: 202 })
 
     const result = await handler(makeReq({
       recipientEmail: 'parent@example.com',
@@ -113,26 +126,19 @@ describe('email shopping list handler', () => {
     }), ctx)
 
     expect(result.status).toBe(202)
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.sendgrid.com/v3/mail/send',
-      expect.objectContaining({
-        method: 'POST',
-        headers: expect.objectContaining({
-          Authorization: 'Bearer test-key',
-        }),
-      })
-    )
+    expect(mockBeginSend).toHaveBeenCalledOnce()
 
-    const payload = JSON.parse(fetchMock.mock.calls[0][1].body)
-    expect(payload.personalizations[0].to[0].email).toBe('parent@example.com')
-    expect(payload.subject).toBe('Shopping List: Campout')
-    expect(payload.content[0].value).toContain('Beans: 2 can')
-    expect(payload.content[0].value).toContain('Salt: 1.5 tsp')
+    const message = mockBeginSend.mock.calls[0][0]
+    expect(message.senderAddress).toBe('DoNotReply@acs-scout-meal-planner.azurecomm.net')
+    expect(message.recipients.to[0].address).toBe('parent@example.com')
+    expect(message.content.subject).toBe('Shopping List: Campout')
+    expect(message.content.plainText).toContain('Beans: 2 can')
+    expect(message.content.plainText).toContain('Salt: 1.5 tsp')
   })
 
-  it('returns 502 when SendGrid returns an error', async () => {
+  it('returns 502 when ACS returns an error status', async () => {
     vi.mocked(getTroopContext).mockResolvedValueOnce(scoutAuth)
-    fetchMock.mockResolvedValueOnce({ ok: false, text: () => Promise.resolve('bad request') })
+    mockPollUntilDone.mockResolvedValueOnce({ status: 'Failed', error: { message: 'bad request' } })
 
     const result = await handler(makeReq({
       recipientEmail: 'parent@example.com',

--- a/api/src/functions/emailShoppingList.ts
+++ b/api/src/functions/emailShoppingList.ts
@@ -1,11 +1,28 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions'
+import { EmailClient } from '@azure/communication-email'
+import { DefaultAzureCredential } from '@azure/identity'
 import { getById } from '../cosmosdb.js'
 import { getTroopContext, unauthorized, forbidden } from '../middleware/auth.js'
 import { checkPermission } from '../middleware/roles.js'
 import { emailShoppingListSchema, validationError } from '../schemas.js'
 
 const EVENTS_CONTAINER = 'events'
-const SENDGRID_API_URL = 'https://api.sendgrid.com/v3/mail/send'
+
+let emailClient: EmailClient | undefined
+
+function getEmailClient(): EmailClient {
+  if (!emailClient) {
+    const endpoint = process.env.ACS_ENDPOINT
+    if (!endpoint) throw new Error('ACS_ENDPOINT is not configured')
+    emailClient = new EmailClient(`https://${endpoint}`, new DefaultAzureCredential())
+  }
+  return emailClient
+}
+
+/** @internal Exposed for testing only */
+export function _setEmailClient(client: EmailClient | undefined) {
+  emailClient = client
+}
 
 function escapeHtml(value: string): string {
   return value
@@ -31,11 +48,17 @@ async function emailShoppingListHandler(req: HttpRequest, context: InvocationCon
     const existingEvent = await getById<any>(EVENTS_CONTAINER, eventId, auth.troopId)
     if (!existingEvent) return { status: 404, jsonBody: { error: 'Event not found' } }
 
-    const sendGridApiKey = process.env.SENDGRID_API_KEY
-    const fromEmail = process.env.SENDGRID_FROM_EMAIL
+    const fromEmail = process.env.ACS_FROM_EMAIL
+    if (!fromEmail) {
+      context.error('Missing ACS_FROM_EMAIL')
+      return { status: 500, jsonBody: { error: 'Email service not configured' } }
+    }
 
-    if (!sendGridApiKey || !fromEmail) {
-      context.error('Missing SENDGRID_API_KEY or SENDGRID_FROM_EMAIL')
+    let client: EmailClient
+    try {
+      client = getEmailClient()
+    } catch {
+      context.error('Missing ACS_ENDPOINT')
       return { status: 500, jsonBody: { error: 'Email service not configured' } }
     }
 
@@ -53,32 +76,21 @@ async function emailShoppingListHandler(req: HttpRequest, context: InvocationCon
       })
       .join('')
 
-    const response = await fetch(SENDGRID_API_URL, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${sendGridApiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        personalizations: [{ to: [{ email: recipientEmail }] }],
-        from: { email: fromEmail },
+    const message = {
+      senderAddress: fromEmail,
+      recipients: { to: [{ address: recipientEmail }] },
+      content: {
         subject: `Shopping List: ${resolvedEventName}`,
-        content: [
-          {
-            type: 'text/plain',
-            value: `Shopping list for ${resolvedEventName}\n\n${textRows}`,
-          },
-          {
-            type: 'text/html',
-            value: `<h2>Shopping list for ${escapeHtml(resolvedEventName)}</h2><table style="border-collapse:collapse;"><thead><tr><th style="padding:4px 8px;text-align:left;">Item</th><th style="padding:4px 8px;text-align:right;">Quantity</th><th style="padding:4px 8px;text-align:left;">Unit</th></tr></thead><tbody>${htmlRows}</tbody></table>`,
-          },
-        ],
-      }),
-    })
+        plainText: `Shopping list for ${resolvedEventName}\n\n${textRows}`,
+        html: `<h2>Shopping list for ${escapeHtml(resolvedEventName)}</h2><table style="border-collapse:collapse;"><thead><tr><th style="padding:4px 8px;text-align:left;">Item</th><th style="padding:4px 8px;text-align:right;">Quantity</th><th style="padding:4px 8px;text-align:left;">Unit</th></tr></thead><tbody>${htmlRows}</tbody></table>`,
+      },
+    }
 
-    if (!response.ok) {
-      const sendGridError = await response.text()
-      context.error('SendGrid request failed:', sendGridError)
+    const poller = await client.beginSend(message)
+    const result = await poller.pollUntilDone()
+
+    if (result.status !== 'Succeeded') {
+      context.error('ACS email send failed:', result.error)
       return { status: 502, jsonBody: { error: 'Failed to send email' } }
     }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -36,6 +36,9 @@ param contentSafetyAccountName string = 'cs-scout-meal-planner'
 @description('Name of the Azure Communication Services resource')
 param communicationServiceName string = 'acs-scout-meal-planner'
 
+@description('Client ID of the pre-created Entra app registration for MSAL sign-in')
+param entraClientId string = '42871bb7-a693-4d97-9cb9-69bbf9a50ff4'
+
 resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
   name: resourceGroupName
   location: location
@@ -54,6 +57,7 @@ module resources 'resources.bicep' = {
     functionAppName: functionAppName
     storageAccountName: storageAccountName
     deployerPrincipalId: deployerPrincipalId
+    entraClientId: entraClientId
     contentSafetyAccountName: contentSafetyAccountName
     communicationServiceName: communicationServiceName
   }
@@ -62,6 +66,6 @@ module resources 'resources.bicep' = {
 output staticWebAppUrl string = resources.outputs.staticWebAppUrl
 output cosmosAccountEndpoint string = resources.outputs.cosmosAccountEndpoint
 output functionAppName string = resources.outputs.functionAppName
-output msaAppClientId string = resources.outputs.msaAppClientId
+output entraClientId string = resources.outputs.entraClientId
 output contentSafetyEndpoint string = resources.outputs.contentSafetyEndpoint
 output acsEndpoint string = resources.outputs.acsEndpoint

--- a/infra/parameters.json
+++ b/infra/parameters.json
@@ -26,6 +26,9 @@
     "deployerPrincipalId": {
       "value": "c96e135f-f098-489f-bb15-07894d415ebe"
     },
+    "entraClientId": {
+      "value": "42871bb7-a693-4d97-9cb9-69bbf9a50ff4"
+    },
     "contentSafetyAccountName": {
       "value": "cs-scout-meal-planner"
     },

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -41,6 +41,9 @@ param contentSafetyAccountName string
 @description('Name of the Azure Communication Services resource')
 param communicationServiceName string
 
+@description('Sender address for ACS Email (must be from a verified domain)')
+param acsFromEmail string = ''
+
 // Cosmos DB Account — Serverless
 resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
   name: cosmosAccountName
@@ -234,6 +237,7 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
         { name: 'ENTRA_CLIENT_ID', value: entraClientId }
         { name: 'CONTENT_SAFETY_ENDPOINT', value: contentSafety.properties.endpoint }
         { name: 'ACS_ENDPOINT', value: communicationService.properties.hostName }
+        { name: 'ACS_FROM_EMAIL', value: acsFromEmail }
       ]
     }
     httpsOnly: true

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -1,5 +1,3 @@
-extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:0.1.8-preview'
-
 @description('Azure region for all resources')
 param location string
 
@@ -27,8 +25,8 @@ param storageAccountName string
 @description('Object ID of the GitHub Actions service principal for deployment')
 param deployerPrincipalId string = ''
 
-@description('Display name for the MSA sign-in app registration')
-param msaAppDisplayName string = 'ScoutMealPlanner'
+@description('Client ID of the pre-created Entra app registration for MSAL sign-in')
+param entraClientId string
 
 @description('Maximum instance count for Flex Consumption scaling')
 param maximumInstanceCount int = 100
@@ -233,7 +231,7 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
         { name: 'AzureWebJobsStorage__tableServiceUri', value: 'https://${storageAccount.name}.table.${environment().suffixes.storage}' }
         { name: 'COSMOS_ENDPOINT', value: cosmosAccount.properties.documentEndpoint }
         { name: 'COSMOS_DATABASE', value: cosmosDatabaseName }
-        { name: 'ENTRA_CLIENT_ID', value: msaApp.appId }
+        { name: 'ENTRA_CLIENT_ID', value: entraClientId }
         { name: 'CONTENT_SAFETY_ENDPOINT', value: contentSafety.properties.endpoint }
         { name: 'ACS_ENDPOINT', value: communicationService.properties.hostName }
       ]
@@ -340,19 +338,6 @@ resource swaBackend 'Microsoft.Web/staticSites/linkedBackends@2023-12-01' = {
   }
 }
 
-// ── App Registration: MSA sign-in (Personal Microsoft Accounts only) ──
-resource msaApp 'Microsoft.Graph/applications@v1.0' = {
-  uniqueName: msaAppDisplayName
-  displayName: msaAppDisplayName
-  signInAudience: 'PersonalMicrosoftAccount'
-  spa: {
-    redirectUris: [
-      'http://localhost:5000'
-      'https://${staticWebApp.properties.defaultHostname}'
-    ]
-  }
-}
-
 // ── Azure AI Content Safety ──
 resource contentSafety 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
   name: contentSafetyAccountName
@@ -401,6 +386,6 @@ resource acsRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' 
 output staticWebAppUrl string = staticWebApp.properties.defaultHostname
 output cosmosAccountEndpoint string = cosmosAccount.properties.documentEndpoint
 output functionAppName string = functionApp.name
-output msaAppClientId string = msaApp.appId
+output entraClientId string = entraClientId
 output contentSafetyEndpoint string = contentSafety.properties.endpoint
 output acsEndpoint string = communicationService.properties.hostName


### PR DESCRIPTION
## Summary

Replaces the SendGrid REST API integration with the Azure Communication Services Email SDK, using managed identity authentication.

## Changes

- **emailShoppingList.ts** — rewritten to use \@azure/communication-email\ \EmailClient.beginSend()\ with \DefaultAzureCredential\
- **emailShoppingList.test.ts** — updated mocks for the ACS poller pattern
- **package.json** — added \@azure/communication-email\ dependency
- **.env.example** — replaced \SENDGRID_*\ vars with \ACS_ENDPOINT\ and \ACS_FROM_EMAIL\
- **resources.bicep** — added \csFromEmail\ param and \ACS_FROM_EMAIL\ Function App setting

## Auth model

No API keys needed. The Function App's system-assigned managed identity authenticates to ACS via \DefaultAzureCredential\. The Contributor RBAC assignment was added in PR #103.

## Setup required

After deployment, configure a verified sender domain in ACS (Email → Domains in the portal), then set \ACS_FROM_EMAIL\ to the provisioned sender address.

## Testing

- All 147 API unit tests pass
- All 107 frontend unit tests pass