### PR TITLE
ci: remove paths-ignore to fix required check deadlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'infra/**'
-      - '*.md'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Removes \paths-ignore\ from CI workflow so the required 'Build & Test' check always reports a status. Previously, infra-only PRs could never merge because the check was skipped entirely.