### PR TITLE
feat(infra): add Email Communication Service and Azure-managed domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'infra/**'
-      - '*.md'
   workflow_dispatch:
 
 permissions:

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -69,3 +69,4 @@ output functionAppName string = resources.outputs.functionAppName
 output entraClientId string = resources.outputs.entraClientId
 output contentSafetyEndpoint string = resources.outputs.contentSafetyEndpoint
 output acsEndpoint string = resources.outputs.acsEndpoint
+output acsFromEmail string = resources.outputs.acsFromEmail

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -41,9 +41,6 @@ param contentSafetyAccountName string
 @description('Name of the Azure Communication Services resource')
 param communicationServiceName string
 
-@description('Sender address for ACS Email (must be from a verified domain)')
-param acsFromEmail string = ''
-
 // Cosmos DB Account — Serverless
 resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
   name: cosmosAccountName
@@ -237,7 +234,7 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
         { name: 'ENTRA_CLIENT_ID', value: entraClientId }
         { name: 'CONTENT_SAFETY_ENDPOINT', value: contentSafety.properties.endpoint }
         { name: 'ACS_ENDPOINT', value: communicationService.properties.hostName }
-        { name: 'ACS_FROM_EMAIL', value: acsFromEmail }
+        { name: 'ACS_FROM_EMAIL', value: 'DoNotReply@${emailDomain.properties.fromSenderDomain}' }
       ]
     }
     httpsOnly: true
@@ -367,12 +364,34 @@ resource contentSafetyRoleAssignment 'Microsoft.Authorization/roleAssignments@20
   }
 }
 
-// ── Azure Communication Services ──
+// ── Email Communication Services ──
+resource emailService 'Microsoft.Communication/emailServices@2023-06-01-preview' = {
+  name: '${communicationServiceName}-email'
+  location: 'global'
+  properties: {
+    dataLocation: 'United States'
+  }
+}
+
+// Azure-managed email domain (auto-provisioned sender address)
+resource emailDomain 'Microsoft.Communication/emailServices/domains@2023-06-01-preview' = {
+  parent: emailService
+  name: 'AzureManagedDomain'
+  location: 'global'
+  properties: {
+    domainManagement: 'AzureManaged'
+  }
+}
+
+// ── Azure Communication Services (linked to Email domain) ──
 resource communicationService 'Microsoft.Communication/communicationServices@2023-06-01-preview' = {
   name: communicationServiceName
   location: 'global'
   properties: {
     dataLocation: 'United States'
+    linkedDomains: [
+      emailDomain.id
+    ]
   }
 }
 
@@ -393,3 +412,4 @@ output functionAppName string = functionApp.name
 output entraClientId string = entraClientId
 output contentSafetyEndpoint string = contentSafety.properties.endpoint
 output acsEndpoint string = communicationService.properties.hostName
+output acsFromEmail string = 'DoNotReply@${emailDomain.properties.fromSenderDomain}'


### PR DESCRIPTION
Adds the missing Email Communication Service resources required for ACS email sending:

- **Email Communication Service** (\Microsoft.Communication/emailServices\)
- **Azure-managed domain** (\mailServices/domains/AzureManagedDomain\) — auto-provisions a \DoNotReply@<guid>.azurecomm.net\ sender
- **Linked domains** on the existing ACS resource so it can route emails

The \ACS_FROM_EMAIL\ Function App setting is now derived from the deployed domain instead of requiring manual configuration. The \csFromEmail\ parameter has been removed.

No API code changes — \mailShoppingList.ts\ already uses the correct SDK (\@azure/communication-email\) connecting through the ACS endpoint.