### PR TITLE
fix(deploy): inject VITE_ENTRA_CLIENT_ID at frontend build time

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,8 @@ jobs:
 
       - name: Build frontend
         run: npm run build
+        env:
+          VITE_ENTRA_CLIENT_ID: ${{ secrets.ENTRA_CLIENT_ID }}
 
       - name: Deploy to Azure Static Web Apps
         uses: Azure/static-web-apps-deploy@v1


### PR DESCRIPTION
The frontend build in the deploy workflow was not receiving the \VITE_ENTRA_CLIENT_ID\ environment variable, so Vite baked an empty string into the bundle. MSAL then sent no \client_id\ parameter, causing \AADSTS900144\.

**Fix:** Pass \ENTRA_CLIENT_ID\ secret as \VITE_ENTRA_CLIENT_ID\ env var during the build step.

Also added the \ENTRA_CLIENT_ID\ repo secret (\42871bb7-...\).