### PR TITLE
fix(infra): remove stray closing brace in resources.bicep

### DIFF
--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -267,7 +267,6 @@ resource acrPushRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-
     principalType: 'ServicePrincipal'
   }
 }
-}
 
 // Cosmos DB Built-in Data Contributor role
 var cosmosDataContributorRoleId = '00000000-0000-0000-0000-000000000002'


### PR DESCRIPTION
Removes an extra `}` at line 270 of `infra/resources.bicep` that caused Bicep compilation error BCP007 during infra deployment.