### PR TITLE
infra: migrate API hosting from Container Apps to App Service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,7 @@ jobs:
           config_file_location: /
           skip_app_build: true
 
-  # ── API → Container App (needs Azure Login — push/dispatch only, OIDC creds don't match PR subject) ──
+  # ── API → App Service (needs Azure Login — push/dispatch only) ──
   deploy_api:
     needs: changes
     if: |
@@ -93,8 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Deploy API
     env:
-      ACR_NAME: crscoutmealplanner
-      CONTAINER_APP_NAME: ca-scout-meal-planner
+      APP_NAME: app-scout-meal-planner-api
       RESOURCE_GROUP: rg-scout-meal-planner
     steps:
       - uses: actions/checkout@v4
@@ -106,22 +105,16 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Login to ACR
-        run: az acr login --name $ACR_NAME
-
-      - name: Build and push container image
+      - name: Deploy to App Service
         run: |
-          IMAGE="${ACR_NAME}.azurecr.io/${CONTAINER_APP_NAME}:${{ github.sha }}"
-          docker build -t "$IMAGE" -t "${ACR_NAME}.azurecr.io/${CONTAINER_APP_NAME}:latest" api/
-          docker push "$IMAGE"
-          docker push "${ACR_NAME}.azurecr.io/${CONTAINER_APP_NAME}:latest"
-
-      - name: Deploy to Container App
-        run: |
-          az containerapp update \
-            --name $CONTAINER_APP_NAME \
+          cd api
+          zip -r ../api.zip . -x '.git/*' '__pycache__/*' '*.pyc' 'node_modules/*' 'src/*' 'dist/*' '.funcignore' 'tsconfig.json' 'package*.json'
+          cd ..
+          az webapp deploy \
+            --name $APP_NAME \
             --resource-group $RESOURCE_GROUP \
-            --image "${ACR_NAME}.azurecr.io/${CONTAINER_APP_NAME}:${{ github.sha }}"
+            --src-path api.zip \
+            --type zip
 
   # ── PR cleanup ──
   close_pull_request:

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -35,7 +35,7 @@ jobs:
             --query "properties.outputs" -o json)
           echo "SWA URL: $(echo $result | jq -r '.staticWebAppUrl.value')"
           echo "Cosmos endpoint: $(echo $result | jq -r '.cosmosAccountEndpoint.value')"
-          echo "Function App: $(echo $result | jq -r '.functionAppName.value')"
+          echo "API App: $(echo $result | jq -r '.apiAppName.value')"
           echo "Content Safety: $(echo $result | jq -r '.contentSafetyEndpoint.value')"
 
       - name: Get SWA deployment token

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -21,17 +21,11 @@ param repositoryUrl string = ''
 @description('GitHub branch for SWA deployment')
 param repositoryBranch string = 'main'
 
-@description('Name of the Container App')
-param containerAppName string = 'ca-scout-meal-planner'
+@description('Name of the App Service Plan')
+param appServicePlanName string = 'plan-scout-meal-planner'
 
-@description('Name of the Container Apps Environment')
-param containerAppEnvName string = 'cae-scout-meal-planner'
-
-@description('Name of the Azure Container Registry')
-param containerRegistryName string = 'crscoutmealplanner'
-
-@description('Object ID of the GitHub Actions service principal for deployment')
-param deployerPrincipalId string = ''
+@description('Name of the API Web App')
+param apiAppName string = 'app-scout-meal-planner-api'
 
 @description('Name of the Azure AI Content Safety account')
 param contentSafetyAccountName string = 'cs-scout-meal-planner'
@@ -57,10 +51,8 @@ module resources 'resources.bicep' = {
     cosmosDatabaseName: cosmosDatabaseName
     repositoryUrl: repositoryUrl
     repositoryBranch: repositoryBranch
-    containerAppName: containerAppName
-    containerAppEnvName: containerAppEnvName
-    containerRegistryName: containerRegistryName
-    deployerPrincipalId: deployerPrincipalId
+    appServicePlanName: appServicePlanName
+    apiAppName: apiAppName
     entraClientId: entraClientId
     contentSafetyAccountName: contentSafetyAccountName
     communicationServiceName: communicationServiceName
@@ -69,9 +61,8 @@ module resources 'resources.bicep' = {
 
 output staticWebAppUrl string = resources.outputs.staticWebAppUrl
 output cosmosAccountEndpoint string = resources.outputs.cosmosAccountEndpoint
-output containerAppName string = resources.outputs.containerAppName
-output containerAppFqdn string = resources.outputs.containerAppFqdn
-output containerRegistryLoginServer string = resources.outputs.containerRegistryLoginServer
+output apiAppName string = resources.outputs.apiAppName
+output apiAppDefaultHostname string = resources.outputs.apiAppDefaultHostname
 output entraClientId string = resources.outputs.entraClientId
 output contentSafetyEndpoint string = resources.outputs.contentSafetyEndpoint
 output acsEndpoint string = resources.outputs.acsEndpoint

--- a/infra/parameters.json
+++ b/infra/parameters.json
@@ -23,9 +23,6 @@
     "repositoryBranch": {
       "value": "main"
     },
-    "deployerPrincipalId": {
-      "value": "c96e135f-f098-489f-bb15-07894d415ebe"
-    },
     "entraClientId": {
       "value": "42871bb7-a693-4d97-9cb9-69bbf9a50ff4"
     },

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -16,17 +16,11 @@ param repositoryUrl string
 @description('GitHub branch')
 param repositoryBranch string
 
-@description('Name of the Container App')
-param containerAppName string
+@description('Name of the App Service Plan')
+param appServicePlanName string
 
-@description('Name of the Container Apps Environment')
-param containerAppEnvName string
-
-@description('Name of the Azure Container Registry')
-param containerRegistryName string
-
-@description('Object ID of the GitHub Actions service principal for deployment')
-param deployerPrincipalId string = ''
+@description('Name of the API Web App')
+param apiAppName string
 
 @description('Client ID of the pre-created Entra app registration for MSAL sign-in')
 param entraClientId string
@@ -147,137 +141,57 @@ resource membersContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/co
   }
 }
 
-// Azure Container Registry
-resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
-  name: containerRegistryName
+// App Service Plan — Linux B1
+resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: appServicePlanName
   location: location
+  kind: 'linux'
   sku: {
-    name: 'Basic'
+    name: 'B1'
+    tier: 'Basic'
   }
   properties: {
-    adminUserEnabled: false
+    reserved: true // Required for Linux
   }
 }
 
-// Log Analytics Workspace for Container Apps Environment
-resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
-  name: '${containerAppEnvName}-logs'
-  location: location
-  properties: {
-    sku: {
-      name: 'PerGB2018'
-    }
-    retentionInDays: 30
-  }
-}
-
-// Container Apps Environment
-resource containerAppEnv 'Microsoft.App/managedEnvironments@2024-03-01' = {
-  name: containerAppEnvName
-  location: location
-  properties: {
-    appLogsConfiguration: {
-      destination: 'log-analytics'
-      logAnalyticsConfiguration: {
-        customerId: logAnalytics.properties.customerId
-        sharedKey: logAnalytics.listKeys().primarySharedKey
-      }
-    }
-  }
-}
-
-// Container App — FastAPI backend
-resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
-  name: containerAppName
+// Web App — Python FastAPI
+resource apiApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: apiAppName
   location: location
   identity: {
     type: 'SystemAssigned'
   }
   properties: {
-    managedEnvironmentId: containerAppEnv.id
-    configuration: {
-      ingress: {
-        external: true
-        targetPort: 8000
-        transport: 'auto'
-        allowInsecure: false
-      }
-      registries: [
-        {
-          server: containerRegistry.properties.loginServer
-          identity: 'system'
-        }
+    serverFarmId: appServicePlan.id
+    httpsOnly: true
+    siteConfig: {
+      linuxFxVersion: 'PYTHON|3.12'
+      appCommandLine: 'uvicorn app.main:app --host 0.0.0.0 --port 8000'
+      appSettings: [
+        { name: 'COSMOS_ENDPOINT', value: cosmosAccount.properties.documentEndpoint }
+        { name: 'COSMOS_DATABASE', value: cosmosDatabaseName }
+        { name: 'ENTRA_CLIENT_ID', value: entraClientId }
+        { name: 'CONTENT_SAFETY_ENDPOINT', value: contentSafety.properties.endpoint }
+        { name: 'ACS_ENDPOINT', value: communicationService.properties.hostName }
+        { name: 'ACS_FROM_EMAIL', value: 'DoNotReply@${emailDomain.properties.fromSenderDomain}' }
+        { name: 'SCM_DO_BUILD_DURING_DEPLOYMENT', value: 'true' }
+        { name: 'WEBSITES_PORT', value: '8000' }
       ]
     }
-    template: {
-      containers: [
-        {
-          name: 'api'
-          image: '${containerRegistry.properties.loginServer}/${containerAppName}:latest'
-          resources: {
-            cpu: json('0.25')
-            memory: '0.5Gi'
-          }
-          env: [
-            { name: 'COSMOS_ENDPOINT', value: cosmosAccount.properties.documentEndpoint }
-            { name: 'COSMOS_DATABASE', value: cosmosDatabaseName }
-            { name: 'ENTRA_CLIENT_ID', value: entraClientId }
-            { name: 'CONTENT_SAFETY_ENDPOINT', value: contentSafety.properties.endpoint }
-            { name: 'ACS_ENDPOINT', value: communicationService.properties.hostName }
-            { name: 'ACS_FROM_EMAIL', value: 'DoNotReply@${emailDomain.properties.fromSenderDomain}' }
-          ]
-        }
-      ]
-      scale: {
-        minReplicas: 0
-        maxReplicas: 5
-        rules: [
-          {
-            name: 'http-scaling'
-            http: {
-              metadata: {
-                concurrentRequests: '50'
-              }
-            }
-          }
-        ]
-      }
-    }
-  }
-}
-
-// ACR Pull role for Container App managed identity
-resource acrPullRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(containerRegistry.id, containerApp.id, '7f951dda-4ed3-4680-a7ca-43fe172d538d')
-  scope: containerRegistry
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
-    principalId: containerApp.identity.principalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-// ACR Push role for deployer SP (to push container images)
-resource acrPushRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (deployerPrincipalId != '') {
-  name: guid(containerRegistry.id, deployerPrincipalId, '8311e382-0749-4cb8-b61a-304f252e45ec')
-  scope: containerRegistry
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8311e382-0749-4cb8-b61a-304f252e45ec')
-    principalId: deployerPrincipalId
-    principalType: 'ServicePrincipal'
   }
 }
 
 // Cosmos DB Built-in Data Contributor role
 var cosmosDataContributorRoleId = '00000000-0000-0000-0000-000000000002'
 
-// Assign Cosmos DB data contributor role to Container App managed identity
+// Assign Cosmos DB data contributor role to Web App managed identity
 resource cosmosRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-05-15' = {
   parent: cosmosAccount
-  name: guid(cosmosAccount.id, containerApp.id, cosmosDataContributorRoleId)
+  name: guid(cosmosAccount.id, apiApp.id, cosmosDataContributorRoleId)
   properties: {
     roleDefinitionId: '${cosmosAccount.id}/sqlRoleDefinitions/${cosmosDataContributorRoleId}'
-    principalId: containerApp.identity.principalId
+    principalId: apiApp.identity.principalId
     scope: cosmosAccount.id
   }
 }
@@ -300,12 +214,12 @@ resource staticWebApp 'Microsoft.Web/staticSites@2023-12-01' = {
   }
 }
 
-// Link Container App as SWA backend
+// Link Web App as SWA backend
 resource swaBackend 'Microsoft.Web/staticSites/linkedBackends@2023-12-01' = {
   parent: staticWebApp
   name: 'backend'
   properties: {
-    backendResourceId: containerApp.id
+    backendResourceId: apiApp.id
     region: location
   }
 }
@@ -324,13 +238,13 @@ resource contentSafety 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
   }
 }
 
-// Cognitive Services User role for Container App managed identity
+// Cognitive Services User role for Web App managed identity
 resource contentSafetyRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(contentSafety.id, containerApp.id, 'a97b65f3-24c7-4388-baec-2e87135dc908')
+  name: guid(contentSafety.id, apiApp.id, 'a97b65f3-24c7-4388-baec-2e87135dc908')
   scope: contentSafety
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'a97b65f3-24c7-4388-baec-2e87135dc908')
-    principalId: containerApp.identity.principalId
+    principalId: apiApp.identity.principalId
     principalType: 'ServicePrincipal'
   }
 }
@@ -366,22 +280,21 @@ resource communicationService 'Microsoft.Communication/communicationServices@202
   }
 }
 
-// Contributor role for Container App managed identity on ACS
+// Contributor role for Web App managed identity on ACS
 resource acsRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(communicationService.id, containerApp.id, 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+  name: guid(communicationService.id, apiApp.id, 'b24988ac-6180-42a0-ab88-20f7382dd24c')
   scope: communicationService
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
-    principalId: containerApp.identity.principalId
+    principalId: apiApp.identity.principalId
     principalType: 'ServicePrincipal'
   }
 }
 
 output staticWebAppUrl string = staticWebApp.properties.defaultHostname
 output cosmosAccountEndpoint string = cosmosAccount.properties.documentEndpoint
-output containerAppName string = containerApp.name
-output containerAppFqdn string = containerApp.properties.configuration.ingress.fqdn
-output containerRegistryLoginServer string = containerRegistry.properties.loginServer
+output apiAppName string = apiApp.name
+output apiAppDefaultHostname string = apiApp.properties.defaultHostName
 output entraClientId string = entraClientId
 output contentSafetyEndpoint string = contentSafety.properties.endpoint
 output acsEndpoint string = communicationService.properties.hostName


### PR DESCRIPTION
## Summary

Replaces Azure Container Apps infrastructure with Azure App Service for the Python FastAPI backend. The Container Apps deployment was timing out on first provisioning (28+ minutes) due to the chicken-and-egg problem of needing a container image in ACR before the Container App could start.

## Changes

### Infrastructure (Bicep)
- **Removed**: Azure Container Registry (ACR), Log Analytics workspace, Container Apps Environment, Container App
- **Added**: App Service Plan (Linux B1) and Web App (Python 3.12) with managed identity
- **Updated**: SWA linked backend now points to the Web App
- **Updated**: Cosmos DB, Content Safety, and ACS role assignments use Web App's managed identity
- **Removed**: `deployerPrincipalId` parameter (was only used for ACR push role)

### CI/CD
- **deploy.yml**: Replaced Docker build/push/container app update with zip deploy to App Service
- **infra.yml**: Updated output references

### App Service Configuration
- Linux Python 3.12 runtime
- Startup command: `uvicorn app.main:app --host 0.0.0.0 --port 8000`
- `SCM_DO_BUILD_DURING_DEPLOYMENT=true` for Oryx build (pip install)
- System-assigned managed identity for Cosmos DB, Content Safety, ACS access