### PR TITLE
chore: add api.zip to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ pids
 .file-manifest
 
 .spark-workbench-id
+api.zip
 api/local.settings.json
 api/dist/
 api/node_modules/


### PR DESCRIPTION
Add `api.zip` to `.gitignore` — this is a build artifact from the App Service zip deploy and should not be checked in.