### PR TITLE
docs: rewrite CONTRIBUTING.md to match current architecture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,63 +1,101 @@
 # Contributing to Scout Meal Planner
 
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| **Frontend** | React 19, Vite, TypeScript (strict mode), Tailwind CSS, Radix UI / shadcn/ui, TanStack Query |
+| **Backend** | Python FastAPI, Pydantic, Uvicorn |
+| **Database** | Azure Cosmos DB |
+| **Auth** | MSAL / Azure Entra ID (frontend), JWT validation (API) |
+| **Deploy** | Azure Static Web Apps (frontend), Azure App Service (API) |
+| **CI** | GitHub Actions — build, test, lint, CodeQL |
+
+## Local Development
+
+The recommended setup uses the **devcontainer** (VS Code / GitHub Codespaces), which provisions Node, Python, and a Cosmos DB emulator automatically.
+
+```bash
+# Devcontainer handles setup via postCreateCommand:
+npm install
+cd api && pip install -r requirements.txt -r requirements-dev.txt
+```
+
+To run locally outside the devcontainer, you need:
+
+- **Node.js** (see `.nvmrc` for version)
+- **Python 3.13+**
+- **Azure Cosmos DB Emulator** running on `https://localhost:8081/`
+
+See [README.md](README.md#local-development) for full setup instructions.
+
+## Build, Test & Lint
+
+Run the full validation before opening a PR:
+
+```bash
+# Frontend
+npm run build          # Build frontend
+npm test               # Vitest unit tests
+npm run test:watch     # Watch mode
+npm run lint           # ESLint
+
+# API
+cd api && python -m pytest   # pytest unit tests
+```
+
 ## Branching Strategy (Trunk-Based)
 
-This project uses a trunk-based workflow. All work happens on short-lived branches off `main`.
+All work happens on short-lived branches off `main`. There is no `develop` branch.
 
-### Branch Overview
+### Branch Naming
 
-| Branch | Purpose | Merges Into |
-| ------ | ------- | ----------- |
-| `main` | Production-ready code. Deployed to Azure on push. | — |
-| `feature/*` | New features and enhancements. | `main` |
-| `fix/*` | Bug fixes. | `main` |
-| `hotfix/*` | Emergency production fixes. | `main` |
+| Prefix | Purpose | Example |
+|--------|---------|---------|
+| `feature/` | New features | `feature/meal-photos` |
+| `fix/` | Bug fixes | `fix/shopping-list-bug` |
+| `hotfix/` | Emergency production fixes | `hotfix/fix-login` |
+| `docs/` | Documentation changes | `docs/update-prd` |
+| `copilot/` | Copilot agent work (automated) | `copilot/add-feature-flags` |
+| `issue-<number>-*` | Issue-linked work | `issue-42-add-headcount` |
 
 ### Workflow
 
-```text
-feature/add-meal-photos ──→ main (via PR)
-fix/shopping-list-bug   ──→ main (via PR)
-hotfix/fix-login        ──→ main (via PR)
-```
-
-### Working on a Feature
-
 ```bash
 # Start from main
-git checkout main
-git pull origin main
+git checkout main && git pull origin main
 git checkout -b feature/my-feature
 
 # ... make changes, commit ...
 
 # Push and create PR targeting main
 git push -u origin feature/my-feature
-# Open PR: feature/my-feature → main
 ```
 
-### Branch Naming Conventions
+## Pull Requests
 
-- `feature/short-description` — new features
-- `fix/short-description` — bug fixes
-- `hotfix/short-description` — emergency production fixes
+- Target `main` with a clear description of what changed and why.
+- **Always include `Closes #<issue-number>`** in the PR description so linked issues auto-close on merge.
+- All PRs require the **Build & Test** check to pass before merging.
+- PRs are squash-merged; branches are deleted automatically after merge.
 
-### CI/CD
+## CI/CD
 
-- **All PRs** (to `main`): CI runs build + tests
-- **Push to `main`**: Deploys to production (Azure Static Web Apps + Azure Functions)
+| Trigger | What runs |
+|---------|-----------|
+| **PR to `main`** | Build & Test (frontend build + tests, API tests), CodeQL, GitGuardian |
+| **Push to `copilot/**` or `docs/**`** | Build & Test (satisfies required checks for agent PRs) |
+| **Push to `main`** | Deploy frontend to Azure Static Web Apps, deploy API to Azure App Service |
 
-## Local Development
+## Copilot Agents
 
-```powershell
-.\dev.ps1
-```
+This repo uses **GitHub Copilot coding agents** for automated development. Agents are assigned issues, create branches (`copilot/*`), implement changes, and open PRs.
 
-Requires fnm + Node.js 20 LTS (pinned via `.nvmrc`) and the Azure Cosmos DB Emulator running on `https://localhost:8081/`. See [README.md](README.md#local-development) for full setup instructions.
+When reviewing agent PRs:
 
-## Testing
+- Verify the implementation matches the issue requirements and the [PRD](PRD.md).
+- Check for bugs, security issues, and missing error handling.
+- Use `@copilot` comments to request changes — the agent will address feedback automatically.
+- Agent PRs follow the same CI and review requirements as human PRs.
 
-```bash
-npm test              # Run all tests
-npm run test:watch    # Watch mode
-```
+See [`.github/copilot-instructions.md`](.github/copilot-instructions.md) for the full agent workflow and coding conventions.


### PR DESCRIPTION
Rewrites CONTRIBUTING.md to accurately reflect the current project:

**Added:**
- Tech stack table (React 19, FastAPI, Cosmos DB, Azure Entra ID)
- Devcontainer-based local dev setup
- Full build/test/lint commands including API \pytest\
- Branch naming for \copilot/*\, \docs/*\, \issue-*\ prefixes
- PR conventions: \Closes #<issue>\, squash-merge, auto-delete branches
- CI/CD trigger table including push triggers for agent branches
- Copilot Agents section documenting automated workflow

**Fixed:**
- Deploy target: Azure App Service (was incorrectly listed as Azure Functions)
- Local dev: devcontainer (was \dev.ps1\ + local Cosmos emulator)
- Testing: added API pytest (was frontend-only)