### PR TITLE
chore: fix Copilot agent firewall blocks with pre-firewall setup steps

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -1,22 +1,21 @@
 # Setup steps for GitHub Copilot coding agent
-# Runs after the devcontainer starts, before the agent begins coding.
-# The agent uses these to validate its work (build + test) before opening a PR.
+# These steps run BEFORE the firewall activates, so package downloads succeed.
+# The agent can then build, test, and lint freely in the sandboxed environment.
 
 steps:
+  - uses: actions/setup-node@v4
+    with:
+      node-version: 22
+      cache: npm
+
   - name: Install frontend dependencies
     run: npm ci
 
+  - uses: actions/setup-python@v5
+    with:
+      python-version: '3.13'
+      cache: pip
+      cache-dependency-path: api/requirements*.txt
+
   - name: Install API dependencies
     run: cd api && pip install -r requirements.txt -r requirements-dev.txt
-
-  - name: Build frontend
-    run: npm run build
-
-  - name: Run frontend tests
-    run: npm test
-
-  - name: Run API tests
-    run: cd api && python -m pytest
-
-  - name: Lint
-    run: npm run lint


### PR DESCRIPTION
Fixes the firewall issue where Copilot coding agents can't download packages during their sandbox session.

**Before:** Setup steps only ran \
pm ci\ and \pip install\ directly — these executed after the firewall activated, causing download failures and \ction_required\ blocks.

**After:** Adds \ctions/setup-node@v4\ and \ctions/setup-python@v5\ with dependency caching. These run before the firewall activates, so all packages are pre-installed. Removed the build/test/lint steps since the agent runs those itself during development.

Agents will now be able to fully verify their work (\
pm run build\, \
pm test\, \
pm run lint\, \pytest\) without hitting firewall blocks.