### PR TITLE
feat: remove create-troop flow, add QR code invite to admin

### DIFF
--- a/api/app/routers/troops.py
+++ b/api/app/routers/troops.py
@@ -33,6 +33,7 @@ def _to_first_name(display_name: str) -> str:
 
 @router.post("/troops", status_code=201)
 async def create_troop(body: CreateTroop, claims: RequireToken):
+    raise HTTPException(status_code=403, detail="Troop creation is currently disabled")
     now = int(time.time() * 1000)
     troop_id = str(uuid.uuid4())
     moderation = await moderate_text_fields([ModerationField(field="name", text=body.name)])

--- a/api/tests/test_troops_moderation.py
+++ b/api/tests/test_troops_moderation.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 from app.middleware.moderation import ModerationResult
 from app.routers import troops as troops_router
@@ -8,34 +9,13 @@ from app.schemas import CreateTroop, UpdateTroop
 
 
 @pytest.mark.asyncio
-async def test_create_troop_moderates_name(monkeypatch):
-    captured = {}
-
-    async def fake_moderate_text_fields(fields):
-        captured["fields"] = [(field.field, field.text) for field in fields]
-        return ModerationResult(status="approved", checkedAt=10)
-
-    async def fake_create_item(container, item):
-        captured.setdefault("created", []).append((container, item))
-        return item
-
-    monkeypatch.setattr(troops_router, "moderate_text_fields", fake_moderate_text_fields)
-    monkeypatch.setattr(troops_router, "create_item", fake_create_item)
-
-    await troops_router.create_troop(
-        CreateTroop(name="Troop 123"),
-        SimpleNamespace(userId="user-1", email="user@example.com", displayName="Leader"),
-    )
-
-    assert captured["fields"] == [("name", "Troop 123")]
-    assert captured["created"][0][1]["moderation"] == {
-        "status": "approved",
-        "flaggedFields": [],
-        "checkedAt": 10,
-        "provider": "azure-content-safety",
-        "categories": [],
-        "fieldCategories": [],
-    }
+async def test_create_troop_is_disabled():
+    with pytest.raises(HTTPException) as exc_info:
+        await troops_router.create_troop(
+            CreateTroop(name="Troop 123"),
+            SimpleNamespace(userId="user-1", email="user@example.com", displayName="Leader"),
+        )
+    assert exc_info.value.status_code == 403
 
 
 @pytest.mark.asyncio

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -82,6 +82,13 @@ resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
     consistencyPolicy: {
       defaultConsistencyLevel: 'Session'
     }
+    publicNetworkAccess: 'Enabled'
+    isVirtualNetworkFilterEnabled: false
+    ipRules: [
+      {
+        ipAddressOrRange: '0.0.0.0'
+      }
+    ]
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
                 "lucide-react": "^0.484.0",
                 "marked": "^15.0.7",
                 "next-themes": "^0.4.6",
+                "qrcode.react": "^4.2.0",
                 "react": "^19.0.0",
                 "react-day-picker": "^9.14.0",
                 "react-dom": "^19.0.0",
@@ -10910,6 +10911,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/qrcode.react": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+            "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+            "license": "ISC",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "lucide-react": "^0.484.0",
         "marked": "^15.0.7",
         "next-themes": "^0.4.6",
+        "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-day-picker": "^9.14.0",
         "react-dom": "^19.0.0",

--- a/src/components/InviteQRCode.tsx
+++ b/src/components/InviteQRCode.tsx
@@ -1,0 +1,35 @@
+import { QRCodeSVG } from 'qrcode.react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { QrCode } from '@phosphor-icons/react'
+
+interface InviteQRCodeProps {
+  inviteLink: string
+  troopName?: string
+}
+
+export function InviteQRCode({ inviteLink, troopName }: InviteQRCodeProps) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" disabled={!inviteLink}>
+          <QrCode className="mr-2 h-4 w-4" />
+          QR Code
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Join {troopName || 'Troop'}</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col items-center gap-4 py-4">
+          <div className="rounded-lg bg-white p-4">
+            <QRCodeSVG value={inviteLink} size={256} level="M" />
+          </div>
+          <p className="text-center text-sm text-muted-foreground">
+            Scan this code to join the troop
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/TroopAdmin.tsx
+++ b/src/components/TroopAdmin.tsx
@@ -13,6 +13,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { Copy, UserCircleMinus, CheckCircle, UserCircle } from '@phosphor-icons/react'
 import { toast } from 'sonner'
+import { InviteQRCode } from './InviteQRCode'
 import type { FlaggedContentAction, FlaggedContentItem, MemberStatus, TroopMember, TroopRole } from '@/lib/types'
 
 const CONTENT_SAFETY_MAX_SEVERITY = 6
@@ -263,6 +264,7 @@ export function TroopAdmin() {
                 <Copy className="h-4 w-4" />
               </Button>
             </div>
+            <InviteQRCode inviteLink={inviteLink} troopName={troop?.name} />
             <Dialog open={isAddMemberDialogOpen} onOpenChange={setIsAddMemberDialogOpen}>
               <DialogTrigger asChild>
                 <Button type="button">Add Member</Button>

--- a/src/components/TroopOnboarding.test.tsx
+++ b/src/components/TroopOnboarding.test.tsx
@@ -3,15 +3,13 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TroopOnboarding } from './TroopOnboarding'
 
-const { joinMock, createMock } = vi.hoisted(() => ({
+const { joinMock } = vi.hoisted(() => ({
   joinMock: vi.fn(),
-  createMock: vi.fn(),
 }))
 
 vi.mock('@/lib/api', () => ({
   troopsApi: {
     join: joinMock,
-    create: createMock,
   },
 }))
 
@@ -19,15 +17,13 @@ describe('TroopOnboarding invite links', () => {
   beforeEach(() => {
     window.history.pushState({}, '', '/')
     joinMock.mockReset()
-    createMock.mockReset()
   })
 
-  it('prefills invite code from URL and starts on join tab', () => {
+  it('prefills invite code from URL', () => {
     window.history.pushState({}, '', '/join?code=troop-a3x9')
 
     render(<TroopOnboarding onComplete={vi.fn()} />)
 
-    expect(screen.getByRole('tab', { name: /join troop/i })).toHaveAttribute('data-state', 'active')
     expect(screen.getByLabelText(/invite code/i)).toHaveValue('TROOP-A3X9')
     expect(screen.getByRole('button', { name: /join troop/i })).toBeEnabled()
   })

--- a/src/components/TroopOnboarding.tsx
+++ b/src/components/TroopOnboarding.tsx
@@ -3,9 +3,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { troopsApi } from '@/lib/api'
-import { Campfire, UsersThree } from '@phosphor-icons/react'
 
 interface TroopOnboardingProps {
   onComplete: () => void
@@ -13,30 +11,12 @@ interface TroopOnboardingProps {
 
 export function TroopOnboarding({ onComplete }: TroopOnboardingProps) {
   const search = typeof window !== 'undefined' ? window.location.search : ''
-  const pathname = typeof window !== 'undefined' ? window.location.pathname : ''
   const inviteCodeFromUrl = search
     ? new URLSearchParams(search).get('code')?.trim().toUpperCase() || ''
     : ''
-  const shouldStartOnJoin = (pathname ? pathname === '/join' : false) || inviteCodeFromUrl.length > 0
-  const [troopName, setTroopName] = useState('')
   const [inviteCode, setInviteCode] = useState(inviteCodeFromUrl)
-  const [activeTab, setActiveTab] = useState<'create' | 'join'>(shouldStartOnJoin ? 'join' : 'create')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
-
-  async function handleCreate() {
-    if (!troopName.trim()) return
-    setError('')
-    setLoading(true)
-    try {
-      await troopsApi.create(troopName.trim())
-      onComplete()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to create troop')
-    } finally {
-      setLoading(false)
-    }
-  }
 
   async function handleJoin() {
     if (!inviteCode.trim()) return
@@ -58,60 +38,28 @@ export function TroopOnboarding({ onComplete }: TroopOnboardingProps) {
         <CardHeader className="text-center">
           <CardTitle className="text-2xl">Welcome to Scout Meal Planner</CardTitle>
           <CardDescription>
-            Create a new troop or join an existing one to get started.
+            Join your troop to get started.
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as 'create' | 'join')}>
-            <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="create">
-                <Campfire className="mr-2 h-4 w-4" />
-                Create Troop
-              </TabsTrigger>
-              <TabsTrigger value="join">
-                <UsersThree className="mr-2 h-4 w-4" />
-                Join Troop
-              </TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="create" className="space-y-4 pt-4">
-              <div className="space-y-2">
-                <Label htmlFor="troopName">Troop Name</Label>
-                <Input
-                  id="troopName"
-                  placeholder="e.g., Troop 42"
-                  value={troopName}
-                  onChange={(e) => setTroopName(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
-                />
-              </div>
-              <Button className="w-full" onClick={handleCreate} disabled={loading || !troopName.trim()}>
-                {loading ? 'Creating...' : 'Create Troop'}
-              </Button>
-              <p className="text-sm text-muted-foreground">
-                You&rsquo;ll become the troop admin and get an invite code to share with others.
-              </p>
-            </TabsContent>
-
-            <TabsContent value="join" className="space-y-4 pt-4">
-              <div className="space-y-2">
-                <Label htmlFor="inviteCode">Invite Code</Label>
-                <Input
-                  id="inviteCode"
-                  placeholder="e.g., TROOP-A3X9"
-                  value={inviteCode}
-                  onChange={(e) => setInviteCode(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && handleJoin()}
-                />
-              </div>
-              <Button className="w-full" onClick={handleJoin} disabled={loading || !inviteCode.trim()}>
-                {loading ? 'Joining...' : 'Join Troop'}
-              </Button>
-              <p className="text-sm text-muted-foreground">
-                Ask your troop admin for the invite code. Your membership will be pending until approved.
-              </p>
-            </TabsContent>
-          </Tabs>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="inviteCode">Invite Code</Label>
+              <Input
+                id="inviteCode"
+                placeholder="e.g., TROOP-A3X9"
+                value={inviteCode}
+                onChange={(e) => setInviteCode(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleJoin()}
+              />
+            </div>
+            <Button className="w-full" onClick={handleJoin} disabled={loading || !inviteCode.trim()}>
+              {loading ? 'Joining...' : 'Join Troop'}
+            </Button>
+            <p className="text-sm text-muted-foreground">
+              Ask your troop admin for the invite code. Your membership will be pending until approved.
+            </p>
+          </div>
 
           {error && (
             <p className="mt-4 text-center text-sm text-destructive">{error}</p>


### PR DESCRIPTION
## Summary

Single-troop simplification: removes the create-troop option for new users, adds a QR code invite feature for troop admins, and opens Cosmos DB to Azure datacenter traffic.

## Changes

- **Onboarding**: Remove the Create Troop / Join Troop tabs; new users now see a join-only flow with invite code input
- **API guard**: `POST /troops` returns 403 "Troop creation is currently disabled" (implementation preserved for future re-enablement)
- **QR Code invite**: New `InviteQRCode` dialog in the troop admin card — renders a scannable QR code encoding the troop join URL
- **Tests**: Updated `TroopOnboarding` tests for the join-only UI
- **Infra**: Allow Cosmos DB connections from Azure public datacenters (ipRules 0.0.0.0)

## New dependency

- `qrcode.react` — lightweight SVG QR code renderer