### PR TITLE
Add retry with exponential backoff for Cosmos DB init at startup

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import time
 
@@ -11,6 +12,9 @@ configure_logging()  # must run before any getLogger() calls in routers
 
 from app.cosmosdb import DatabaseUnavailableError, close_database_clients, init_database
 from app.telemetry import track_exception, track_request
+
+_DB_INIT_MAX_RETRIES = 5
+_DB_INIT_BASE_DELAY = 2  # seconds, doubles each retry
 from app.routers import (
     events,
     event_packed,
@@ -31,12 +35,28 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(application: FastAPI):
-    try:
-        await init_database()
-        logger.info("Cosmos DB initialized successfully")
-    except Exception as exc:
-        logger.error("Cosmos DB unavailable at startup — running without database: %s", exc, exc_info=True)
-        track_exception(exc, properties={"phase": "startup", "component": "cosmosdb"})
+    last_exc: Exception | None = None
+    for attempt in range(1, _DB_INIT_MAX_RETRIES + 1):
+        try:
+            await init_database()
+            logger.info("Cosmos DB initialized successfully (attempt %d)", attempt)
+            last_exc = None
+            break
+        except Exception as exc:
+            last_exc = exc
+            delay = _DB_INIT_BASE_DELAY * (2 ** (attempt - 1))
+            logger.warning(
+                "Cosmos DB init attempt %d/%d failed: %s — retrying in %ds",
+                attempt, _DB_INIT_MAX_RETRIES, exc, delay,
+            )
+            if attempt < _DB_INIT_MAX_RETRIES:
+                await asyncio.sleep(delay)
+    if last_exc:
+        logger.error(
+            "Cosmos DB unavailable after %d attempts — running without database: %s",
+            _DB_INIT_MAX_RETRIES, last_exc, exc_info=True,
+        )
+        track_exception(last_exc, properties={"phase": "startup", "component": "cosmosdb"})
     try:
         yield
     finally:


### PR DESCRIPTION
## Problem
The app gets permanently stuck returning 503 if init_database() fails at startup (transient Cosmos DB connectivity issue, managed identity token not yet available).

## Root Cause
init_database() in the lifespan is called once. If it fails, the app runs with empty containers dict and every DB request returns 503.

## Fix
Added exponential backoff retry: up to 5 attempts (2s, 4s, 8s, 16s, 32s) before giving up. Covers managed identity token delays, transient connectivity, and DNS resolution in new containers.

## Testing
All 157 tests pass.

Closes #232